### PR TITLE
Decrease the minSdk to 26

### DIFF
--- a/.github/workflows/compatibilityTest.yml
+++ b/.github/workflows/compatibilityTest.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 28, 34 ]
+        api-level: [ 26, 34 ]
         profile: [ Pixel5, MediumTablet ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
 
     defaultConfig {
         applicationId = "com.futsch1.medtimer"
-        minSdk = 28
+        minSdk = 26
         multiDexEnabled = true
         targetSdk = 35
         versionCode = 91

--- a/app/src/main/java/com/futsch1/medtimer/OptionsMenu.java
+++ b/app/src/main/java/com/futsch1/medtimer/OptionsMenu.java
@@ -20,6 +20,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.view.menu.MenuBuilder;
+import androidx.core.view.MenuCompat;
 import androidx.core.view.MenuProvider;
 import androidx.navigation.Navigation;
 
@@ -63,7 +64,7 @@ public class OptionsMenu implements MenuProvider {
     @Override
     public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
         menuInflater.inflate(R.menu.main, menu);
-        menu.setGroupDividerEnabled(true);
+        MenuCompat.setGroupDividerEnabled(menu, true);
         enableOptionalIcons(menu);
 
         this.backupManager = new BackupManager(context, menu, medicineViewModel, openFileLauncher);

--- a/app/src/main/java/com/futsch1/medtimer/medicine/AdvancedReminderSettingsMenuProvider.kt
+++ b/app/src/main/java/com/futsch1/medtimer/medicine/AdvancedReminderSettingsMenuProvider.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuCompat
 import androidx.core.view.MenuProvider
 import androidx.navigation.Navigation.findNavController
 import com.futsch1.medtimer.MedicineViewModel
@@ -20,7 +21,7 @@ class AdvancedReminderSettingsMenuProvider(
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
         menuInflater.inflate(R.menu.advanced_reminder_settings, menu)
-        menu.setGroupDividerEnabled(true)
+        MenuCompat.setGroupDividerEnabled(menu, true)
 
         menu.findItem(R.id.delete_reminder).setOnMenuItemClickListener { _: MenuItem? ->
             LinkedReminderHandling(reminder, medicineViewModel).deleteReminder(

--- a/app/src/main/java/com/futsch1/medtimer/medicine/EditMedicineMenuProvider.kt
+++ b/app/src/main/java/com/futsch1/medtimer/medicine/EditMedicineMenuProvider.kt
@@ -7,6 +7,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuCompat
 import androidx.core.view.MenuProvider
 import androidx.navigation.Navigation.findNavController
 import com.futsch1.medtimer.MedicineViewModel
@@ -23,7 +24,7 @@ class EditMedicineMenuProvider(
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
         menuInflater.inflate(R.menu.edit_medicine, menu)
-        menu.setGroupDividerEnabled(true)
+        MenuCompat.setGroupDividerEnabled(menu, true)
 
         menu.findItem(R.id.activate_all).setOnMenuItemClickListener { _: MenuItem? ->
             setRemindersActive(true)


### PR DESCRIPTION
Following our discussion in #28, I found the reason why the app crashes on my API 26 emulator and fixed it.

I also tried lower `minSdk` numbers but got these problems:

API 24-25: 
> com.futsch1.medtimer.app-main-70:/mipmap-anydpi/logo.xml: error: <adaptive-icon> elements require a sdk version of at least 26.
> com.futsch1.medtimer.app-main-70:/mipmap-anydpi/logo_round.xml: error: <adaptive-icon> elements require a sdk version of at least 26.

API 23: for value `?android:colorForeground` in `res/drawable/filetype_pdf.xml` and `res/drawable/box_arrow_in_down.xml`
> Resource references will not work correctly in images generated for this vector icon for API < 24

API 22:
> uses-sdk:minSdkVersion 22 cannot be smaller than version 23 declared in library [com.github.wwdablu:SimplyPDF:2.1.1]

If you'd like to decrease the `minSdk` number further, you can try to fix these points from top to down. I'd also like to help!