### PR TITLE
Revert "Decrease the minSdk to 26"

### DIFF
--- a/.github/workflows/compatibilityTest.yml
+++ b/.github/workflows/compatibilityTest.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 26, 34 ]
+        api-level: [ 28, 34 ]
         profile: [ Pixel5, MediumTablet ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
 
     defaultConfig {
         applicationId = "com.futsch1.medtimer"
-        minSdk = 26
+        minSdk = 28
         multiDexEnabled = true
         targetSdk = 35
         versionCode = 91

--- a/app/src/main/java/com/futsch1/medtimer/OptionsMenu.java
+++ b/app/src/main/java/com/futsch1/medtimer/OptionsMenu.java
@@ -20,7 +20,6 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.view.menu.MenuBuilder;
-import androidx.core.view.MenuCompat;
 import androidx.core.view.MenuProvider;
 import androidx.navigation.Navigation;
 
@@ -64,7 +63,7 @@ public class OptionsMenu implements MenuProvider {
     @Override
     public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
         menuInflater.inflate(R.menu.main, menu);
-        MenuCompat.setGroupDividerEnabled(menu, true);
+        menu.setGroupDividerEnabled(true);
         enableOptionalIcons(menu);
 
         this.backupManager = new BackupManager(context, menu, medicineViewModel, openFileLauncher);

--- a/app/src/main/java/com/futsch1/medtimer/medicine/AdvancedReminderSettingsMenuProvider.kt
+++ b/app/src/main/java/com/futsch1/medtimer/medicine/AdvancedReminderSettingsMenuProvider.kt
@@ -5,7 +5,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.core.view.MenuCompat
 import androidx.core.view.MenuProvider
 import androidx.navigation.Navigation.findNavController
 import com.futsch1.medtimer.MedicineViewModel
@@ -21,7 +20,7 @@ class AdvancedReminderSettingsMenuProvider(
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
         menuInflater.inflate(R.menu.advanced_reminder_settings, menu)
-        MenuCompat.setGroupDividerEnabled(menu, true)
+        menu.setGroupDividerEnabled(true)
 
         menu.findItem(R.id.delete_reminder).setOnMenuItemClickListener { _: MenuItem? ->
             LinkedReminderHandling(reminder, medicineViewModel).deleteReminder(

--- a/app/src/main/java/com/futsch1/medtimer/medicine/EditMedicineMenuProvider.kt
+++ b/app/src/main/java/com/futsch1/medtimer/medicine/EditMedicineMenuProvider.kt
@@ -7,7 +7,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.core.view.MenuCompat
 import androidx.core.view.MenuProvider
 import androidx.navigation.Navigation.findNavController
 import com.futsch1.medtimer.MedicineViewModel
@@ -24,7 +23,7 @@ class EditMedicineMenuProvider(
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
         menuInflater.inflate(R.menu.edit_medicine, menu)
-        MenuCompat.setGroupDividerEnabled(menu, true)
+        menu.setGroupDividerEnabled(true)
 
         menu.findItem(R.id.activate_all).setOnMenuItemClickListener { _: MenuItem? ->
             setRemindersActive(true)


### PR DESCRIPTION
Reverts Futsch1/medTimer#389

Crashes in several tests are related to this change - the MinSDK will be kept at 28