### PR TITLE
Fix alarm activity from crashing

### DIFF
--- a/app/src/main/java/com/futsch1/medtimer/alarm/ReminderAlarmActivity.kt
+++ b/app/src/main/java/com/futsch1/medtimer/alarm/ReminderAlarmActivity.kt
@@ -60,7 +60,9 @@ class ReminderAlarmActivity(
             mediaPlayer.stop()
             mediaPlayer.release()
         }
-        vibrator.cancel()
+        if (this::vibrator.isInitialized) {
+            vibrator.cancel()
+        }
     }
 
     private fun startAlarmTone() {


### PR DESCRIPTION
Prior to this commit, the activity crashes with the following exception, causing the alarm to not fire :p
```
10-16 09:13:00.663 13749 13749 E AndroidRuntime: FATAL EXCEPTION: main
10-16 09:13:00.663 13749 13749 E AndroidRuntime: Process: com.futsch1.medtimer, PID: 13749
10-16 09:13:00.663 13749 13749 E AndroidRuntime: java.lang.RuntimeException: Unable to pause activity {com.futsch1.medtimer/com.futsch1.medtimer.alarm.ReminderAlarmActivity}: kotlin.UninitializedPropertyAccessException: lateinit property vibrator has not been initialized
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:5042)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4993)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:4945)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.servertransaction.PauseActivityItem.execute(PauseActivityItem.java:47)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:106)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:201)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:288)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:7839)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
10-16 09:13:00.663 13749 13749 E AndroidRuntime: Caused by: kotlin.UninitializedPropertyAccessException: lateinit property vibrator has not been initialized
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at com.futsch1.medtimer.alarm.ReminderAlarmActivity.onPause(ReminderAlarmActivity.kt:63)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.Activity.performPause(Activity.java:8235)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1530)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:5032)
10-16 09:13:00.663 13749 13749 E AndroidRuntime:        ... 14 more
```