### PR TITLE
Migrate to libs.versions.toml

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    id("com.android.application")
-    id("androidx.room")
-    id("com.github.triplet.play") version "4.0.0"
-    id("androidx.navigation.safeargs")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.androidx.room)
+    alias(libs.plugins.triplet.play)
+    alias(libs.plugins.androidx.navigation.safeargs)
     id("jacoco")
-    id("org.sonarqube") version "7.2.2.6593"
-    id("tech.apter.junit5.jupiter.robolectric-extension-gradle-plugin") version "0.9.0"
+    alias(libs.plugins.sonarqube)
+    alias(libs.plugins.robolectric.junit5)
 }
 
 room {
@@ -103,92 +103,53 @@ android {
 }
 
 dependencies {
-    val appcompatVersion = "1.7.1"
-    val materialVersion = "1.13.0"
-    val constraintLayoutVersion = "2.2.1"
-    val androidXNavigationVersion = "2.9.7"
-    val preferenceKtxVersion = "1.2.1"
-    val lifecycleExtensionsVersion = "2.2.0"
-    val lifecycleKtxVersion = "2.10.0"
-    val workRuntimeVersion = "2.11.1"
-    val coreKtxVersion = "1.17.0"
-    val roomVersion = "2.8.4"
-    val colorPickerViewVersion = "3.1.0"
-    val simplyPDFVersion = "2.1.1"
-    val gsonVersion = "2.13.2"
-    val tableViewVersion = "0.8.9.4"
-    val androidPlotVersion = "1.5.11"
-    val appIntroVersion = "6.3.1"
-    val calendarVersion = "2.10.0"
-    val iconDialogVersion = "3.3.0"
-    val flexboxVersion = "3.0.0"
-    val biometricVersion = "1.1.0"
-    val preferenceExtendedVersion = "1.1.0"
+    implementation(libs.androidx.appcompat)
+    implementation(libs.material)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.navigation.fragment.ktx)
+    implementation(libs.androidx.navigation.ui.ktx)
+    implementation(libs.androidx.preference.ktx)
+    implementation(libs.androidx.lifecycle.extensions)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.work.runtime)
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.color.picker)
+    implementation(libs.simply.pdf)
+    implementation(libs.gson)
+    implementation(libs.tableview)
+    implementation(libs.androidplot)
+    implementation(libs.appintro)
+    implementation(libs.calendar)
+    implementation(libs.icondialog)
+    implementation(libs.espresso.idling.resource)
+    implementation(libs.espresso.idling.concurrent)
+    implementation(libs.flexbox)
+    implementation(libs.androidx.biometric)
+    implementation(libs.preferencex.ringtone)
+    implementation(libs.preferencex)
 
-    val junitVersion = "6.0.3"
-    val mockitoCoreVersion = "5.21.0"
-    val mockitoInlineVersion = "5.2.0"
-    val robolectricVersion = "4.16.1"
-    val jazzerVersion = "0.29.1"
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.inline)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.jazzer.junit)
+    testRuntimeOnly(libs.junit.jupiter.engine)
 
-    val androidTestJunitVersion = "1.3.0"
-    val androidTestEspressoVersion = "3.7.0"
-    val androidTestRulesVersion = "1.7.0"
-    val screengrabVersion = "2.1.1"
-    val uiautomatorVersion = "2.3.0"
-    val androidTestRunnerVersion = "1.7.0"
-    val androidTestOrchestratorVersion = "1.6.1"
-    val baristaVersion = "4.3.0"
+    androidTestImplementation(libs.androidx.test.junit)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.espresso.contrib)
+    androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.screengrab)
+    androidTestImplementation(libs.uiautomator)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.barista)
+    androidTestUtil(libs.androidx.test.orchestrator)
 
-    val desugarJdkVersion = "2.1.5"
+    annotationProcessor(libs.androidx.room.compiler)
 
-    implementation("androidx.appcompat:appcompat:$appcompatVersion")
-    implementation("com.google.android.material:material:$materialVersion")
-    implementation("androidx.constraintlayout:constraintlayout:$constraintLayoutVersion")
-    implementation("androidx.navigation:navigation-fragment-ktx:$androidXNavigationVersion")
-    implementation("androidx.navigation:navigation-ui-ktx:$androidXNavigationVersion")
-    implementation("androidx.preference:preference-ktx:$preferenceKtxVersion")
-    implementation("androidx.lifecycle:lifecycle-extensions:$lifecycleExtensionsVersion")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:${lifecycleKtxVersion}")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:${lifecycleKtxVersion}")
-    implementation("androidx.work:work-runtime:$workRuntimeVersion")
-    implementation("androidx.core:core-ktx:$coreKtxVersion")
-    implementation("androidx.room:room-runtime:$roomVersion")
-    implementation("com.github.martin-stone:hsv-alpha-color-picker-android:$colorPickerViewVersion")
-    implementation("com.github.wwdablu:SimplyPDF:$simplyPDFVersion")
-    implementation("com.google.code.gson:gson:$gsonVersion")
-    implementation("com.github.evrencoskun:TableView:v$tableViewVersion")
-    implementation("com.androidplot:androidplot-core:$androidPlotVersion")
-    implementation("com.github.AppIntro:AppIntro:$appIntroVersion")
-    implementation("com.kizitonwose.calendar:view:$calendarVersion")
-    implementation("com.maltaisn:icondialog:$iconDialogVersion")
-    implementation("androidx.test.espresso:espresso-idling-resource:$androidTestEspressoVersion")
-    implementation("androidx.test.espresso.idling:idling-concurrent:$androidTestEspressoVersion")
-    implementation("com.google.android.flexbox:flexbox:$flexboxVersion")
-    implementation("androidx.biometric:biometric:$biometricVersion")
-    implementation("com.takisoft.preferencex:preferencex-ringtone:$preferenceExtendedVersion")
-    implementation("com.takisoft.preferencex:preferencex:$preferenceExtendedVersion")
-
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoCoreVersion")
-    testImplementation("org.mockito:mockito-inline:$mockitoInlineVersion")
-    testImplementation("org.robolectric:robolectric:$robolectricVersion")
-    testImplementation("com.code-intelligence:jazzer-junit:$jazzerVersion")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-
-    androidTestImplementation("androidx.test.ext:junit:$androidTestJunitVersion")
-    androidTestImplementation("androidx.test.espresso:espresso-core:$androidTestEspressoVersion")
-    androidTestImplementation("androidx.test.espresso:espresso-contrib:$androidTestEspressoVersion")
-    androidTestImplementation("androidx.test:rules:$androidTestRulesVersion")
-    androidTestImplementation("tools.fastlane:screengrab:$screengrabVersion")
-    androidTestImplementation("androidx.test.uiautomator:uiautomator:$uiautomatorVersion")
-    androidTestImplementation("androidx.test:runner:$androidTestRunnerVersion")
-    androidTestImplementation("com.adevinta.android:barista:$baristaVersion")
-    androidTestUtil("androidx.test:orchestrator:$androidTestOrchestratorVersion")
-
-    annotationProcessor("androidx.room:room-compiler:$roomVersion")
-
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:$desugarJdkVersion")
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }
 
 play {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    //noinspection AndroidGradlePluginVersion
-    id("com.android.application") version "9.0.1" apply false
-    id("androidx.room") version "2.8.4" apply false
-    id("androidx.navigation.safeargs") version "2.9.7" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.androidx.room) apply false
+    alias(libs.plugins.androidx.navigation.safeargs) apply false
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,114 @@
+[versions]
+# Plugins
+android-gradle-plugin = "9.0.1"
+navigation-safe-args = "2.9.7"
+room-plugin = "2.8.4"
+triplet-play = "4.0.0"
+sonarqube = "7.2.2.6593"
+robolectric-junit5 = "0.9.0"
+
+# AndroidX
+appcompat = "1.7.1"
+core-ktx = "1.17.0"
+constraintlayout = "2.2.1"
+navigation = "2.9.7"
+preference-ktx = "1.2.1"
+lifecycle-extensions = "2.2.0"
+lifecycle-ktx = "2.10.0"
+work-runtime = "2.11.1"
+room = "2.8.4"
+biometric = "1.1.0"
+espresso = "3.7.0"
+
+# UI / Third-party
+material = "1.13.0"
+color-picker = "3.1.0"
+simply-pdf = "2.1.1"
+gson = "2.13.2"
+androidplot = "1.5.11"
+appintro = "6.3.1"
+calendar = "2.10.0"
+icondialog = "3.3.0"
+flexbox = "3.0.0"
+preference-extended = "1.1.0"
+
+# Testing
+junit = "6.0.3"
+mockito-core = "5.21.0"
+mockito-inline = "5.2.0"
+robolectric = "4.16.1"
+jazzer = "0.29.1"
+android-test-junit = "1.3.0"
+android-test-rules = "1.7.0"
+android-test-runner = "1.7.0"
+android-test-orchestrator = "1.6.1"
+screengrab = "2.1.1"
+uiautomator = "2.3.0"
+barista = "4.3.0"
+
+# Build
+desugar-jdk = "2.1.5"
+
+[libraries]
+# AndroidX
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
+androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigation" }
+androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigation" }
+androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "preference-ktx" }
+androidx-lifecycle-extensions = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "lifecycle-extensions" }
+androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle-ktx" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle-ktx" }
+androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "work-runtime" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
+
+# UI / Third-party
+material = { module = "com.google.android.material:material", version.ref = "material" }
+color-picker = { module = "com.github.martin-stone:hsv-alpha-color-picker-android", version.ref = "color-picker" }
+simply-pdf = { module = "com.github.wwdablu:SimplyPDF", version.ref = "simply-pdf" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+tableview = { module = "com.github.evrencoskun:TableView", version = "v0.8.9.4" }
+androidplot = { module = "com.androidplot:androidplot-core", version.ref = "androidplot" }
+appintro = { module = "com.github.AppIntro:AppIntro", version.ref = "appintro" }
+calendar = { module = "com.kizitonwose.calendar:view", version.ref = "calendar" }
+icondialog = { module = "com.maltaisn:icondialog", version.ref = "icondialog" }
+flexbox = { module = "com.google.android.flexbox:flexbox", version.ref = "flexbox" }
+preferencex = { module = "com.takisoft.preferencex:preferencex", version.ref = "preference-extended" }
+preferencex-ringtone = { module = "com.takisoft.preferencex:preferencex-ringtone", version.ref = "preference-extended" }
+
+# Espresso (used both as implementation and androidTest)
+espresso-idling-resource = { module = "androidx.test.espresso:espresso-idling-resource", version.ref = "espresso" }
+espresso-idling-concurrent = { module = "androidx.test.espresso.idling:idling-concurrent", version.ref = "espresso" }
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+espresso-contrib = { module = "androidx.test.espresso:espresso-contrib", version.ref = "espresso" }
+
+# Unit testing
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito-inline" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+jazzer-junit = { module = "com.code-intelligence:jazzer-junit", version.ref = "jazzer" }
+
+# Android testing
+androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "android-test-junit" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "android-test-rules" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "android-test-runner" }
+androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "android-test-orchestrator" }
+screengrab = { module = "tools.fastlane:screengrab", version.ref = "screengrab" }
+uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
+barista = { module = "com.adevinta.android:barista", version.ref = "barista" }
+
+# Build
+desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar-jdk" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
+androidx-room = { id = "androidx.room", version.ref = "room-plugin" }
+androidx-navigation-safeargs = { id = "androidx.navigation.safeargs", version.ref = "navigation-safe-args" }
+triplet-play = { id = "com.github.triplet.play", version.ref = "triplet-play" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
+robolectric-junit5 = { id = "tech.apter.junit5.jupiter.robolectric-extension-gradle-plugin", version.ref = "robolectric-junit5" }


### PR DESCRIPTION
This PR implements changes proposed in issue #1202 .

All the library versoins have been moved to libs.versions.toml.