### PR TITLE
Fix fragment view field retention leaks

### DIFF
--- a/app/src/main/java/com/futsch1/medtimer/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/futsch1/medtimer/overview/OverviewFragment.kt
@@ -100,7 +100,7 @@ class OverviewFragment : Fragment(), OnFragmentReselectedListener, RemindersView
     lateinit var optionsMenuFactory: OptionsMenu.Factory
     private lateinit var optionsMenu: OptionsMenu
     private lateinit var daySelector: DaySelector
-    private lateinit var fragmentOverview: FragmentSwipeLayout
+    private var fragmentOverview: FragmentSwipeLayout? = null
     private var onceStable = false
     private var actionMode: ActionMode? = null
     private var actionsMenu: ActionsMenu? = null
@@ -128,20 +128,21 @@ class OverviewFragment : Fragment(), OnFragmentReselectedListener, RemindersView
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         NextReminders(this, medicineViewModel, preferencesDataSource, medicineRepository, reminderEventRepository)
 
-        fragmentOverview = inflater.inflate(R.layout.fragment_overview, container, false) as FragmentSwipeLayout
+        val overview = inflater.inflate(R.layout.fragment_overview, container, false) as FragmentSwipeLayout
+        fragmentOverview = overview
 
-        daySelector = DaySelector(requireContext(), fragmentOverview.findViewById(R.id.overviewWeek), overviewViewModel.day) { day -> daySelected(day) }
+        daySelector = DaySelector(requireContext(), overview.findViewById(R.id.overviewWeek), overviewViewModel.day) { day -> daySelected(day) }
 
         requireActivity().addMenuProvider(optionsMenu, getViewLifecycleOwner())
 
-        setupReminders()
+        setupReminders(overview)
 
-        setupLogManualDose()
-        FilterToggleGroup(fragmentOverview.findViewById(R.id.filterButtons), overviewViewModel, persistentDataDataSource)
+        setupLogManualDose(overview)
+        FilterToggleGroup(overview.findViewById(R.id.filterButtons), overviewViewModel, persistentDataDataSource)
 
-        fragmentOverview.onSwipeListener = OverviewOnSwipeListener()
+        overview.onSwipeListener = OverviewOnSwipeListener()
 
-        return fragmentOverview
+        return overview
     }
 
     override fun onResume() {
@@ -167,11 +168,11 @@ class OverviewFragment : Fragment(), OnFragmentReselectedListener, RemindersView
         }
     }
 
-    private fun setupReminders() {
-        reminders = fragmentOverview.findViewById(R.id.reminders)
+    private fun setupReminders(overview: FragmentSwipeLayout) {
+        reminders = overview.findViewById(R.id.reminders)
         adapter = remindersViewAdapterFactory.create(RemindersViewAdapter.OverviewEventDiff(), requireActivity())
         reminders.setAdapter(adapter)
-        reminders.setLayoutManager(LinearLayoutManager(fragmentOverview.context))
+        reminders.setLayoutManager(LinearLayoutManager(overview.context))
         adapter.clickListener = this
 
         viewLifecycleOwner.lifecycleScope.launch(backgroundDispatcher) {
@@ -201,8 +202,8 @@ class OverviewFragment : Fragment(), OnFragmentReselectedListener, RemindersView
         }
     }
 
-    private fun setupLogManualDose() {
-        val logManualDose = fragmentOverview.findViewById<Button>(R.id.logManualDose)
+    private fun setupLogManualDose(overview: FragmentSwipeLayout) {
+        val logManualDose = overview.findViewById<Button>(R.id.logManualDose)
         logManualDose.setOnClickListener { _: View? ->
             lifecycleScope.launch {
                 manualDoseFactory.create(requireContext(), medicineViewModel, requireActivity(), overviewViewModel.day).logManualDose()
@@ -214,6 +215,11 @@ class OverviewFragment : Fragment(), OnFragmentReselectedListener, RemindersView
         overviewViewModel.day = date
     }
 
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        fragmentOverview = null
+    }
 
     override fun onDestroy() {
         super.onDestroy()

--- a/app/src/main/java/com/futsch1/medtimer/remindertable/ReminderTableFragment.kt
+++ b/app/src/main/java/com/futsch1/medtimer/remindertable/ReminderTableFragment.kt
@@ -24,8 +24,8 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class ReminderTableFragment : Fragment() {
-    private lateinit var filterLayout: TextInputLayout
-    private lateinit var filter: TextInputEditText
+    private var filterLayout: TextInputLayout? = null
+    private var filter: TextInputEditText? = null
 
     @Inject
     lateinit var timeFormatter: TimeFormatter
@@ -60,11 +60,11 @@ class ReminderTableFragment : Fragment() {
             medicineViewModel.getLiveReminderEvents(0, ReminderEvent.statusValuesTakenOrSkipped)
                 .collect { reminderEvents ->
                     adapter.submitList(reminderEvents)
-                    tableFilter.set(filter.text.toString())
+                    tableFilter.set(filter?.text?.toString() ?: "")
                 }
         }
 
-        // This is a workaround for a recycler view bug that causes random crashes
+        // workaround for a recycler view bug that causes random crashes
         tableView.cellRecyclerView.setItemAnimator(null)
         tableView.columnHeaderRecyclerView.setItemAnimator(null)
         tableView.rowHeaderRecyclerView.setItemAnimator(null)
@@ -77,12 +77,18 @@ class ReminderTableFragment : Fragment() {
         return fragmentView
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        filter = null
+        filterLayout = null
+    }
+
     private fun setupFilter(tableFilter: Filter) {
-        filterLayout.setEndIconOnClickListener { _: View? ->
-            filter.setText("")
+        filterLayout?.setEndIconOnClickListener { _: View? ->
+            filter?.setText("")
             tableFilter.set("")
         }
-        filter.addTextChangedListener(object : TextWatcher {
+        filter?.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable?) {
                 // Intentionally empty
             }

--- a/app/src/main/java/com/futsch1/medtimer/statistics/ChartsFragment.kt
+++ b/app/src/main/java/com/futsch1/medtimer/statistics/ChartsFragment.kt
@@ -58,9 +58,9 @@ class ChartsFragment : Fragment() {
     @Inject
     lateinit var timeFormatter: TimeFormatter
 
-    private lateinit var takenSkippedChartView: PieChart
-    private lateinit var takenSkippedTotalChartView: PieChart
-    private lateinit var medicinesPerDayChartView: XYPlot
+    private var takenSkippedChartView: PieChart? = null
+    private var takenSkippedTotalChartView: PieChart? = null
+    private var medicinesPerDayChartView: XYPlot? = null
 
     private lateinit var segmentTakenPeriod: Segment
     private lateinit var segmentSkippedPeriod: Segment
@@ -76,17 +76,22 @@ class ChartsFragment : Fragment() {
     ): View {
         val statisticsView = inflater.inflate(R.layout.fragment_charts, container, false)
 
-        medicinesPerDayChartView = statisticsView.findViewById(R.id.medicinesPerDayChart)
-        takenSkippedChartView = statisticsView.findViewById(R.id.takenSkippedChart)
-        takenSkippedTotalChartView = statisticsView.findViewById(R.id.takenSkippedChartTotal)
+        val medicinesPerDayChartView: XYPlot = statisticsView.findViewById(R.id.medicinesPerDayChart)
+        val takenSkippedChartView: PieChart = statisticsView.findViewById(R.id.takenSkippedChart)
+        val takenSkippedTotalChartView: PieChart = statisticsView.findViewById(R.id.takenSkippedChartTotal)
+        this.medicinesPerDayChartView = medicinesPerDayChartView
+        this.takenSkippedChartView = takenSkippedChartView
+        this.takenSkippedTotalChartView = takenSkippedTotalChartView
 
-        setupTakenSkippedCharts()
-        setupMedicinesPerDayChart()
+        setupTakenSkippedCharts(takenSkippedChartView, takenSkippedTotalChartView)
+        setupMedicinesPerDayChart(medicinesPerDayChartView)
         val uiState = viewModel.uiState
         viewLifecycleOwner.lifecycleScope.launch(backgroundDispatcher) {
             uiState.filterNotNull().collect { state ->
                 withContext(mainDispatcher) {
                     updateMedicinesPerDayChart(state)
+                    val takenSkippedChartView = takenSkippedChartView ?: return@withContext
+                    val takenSkippedTotalChartView = takenSkippedTotalChartView ?: return@withContext
                     updateTakenSkipped(
                         takenSkippedChartView,
                         segmentTakenPeriod,
@@ -110,7 +115,14 @@ class ChartsFragment : Fragment() {
         return statisticsView
     }
 
-    private fun setupTakenSkippedCharts() {
+    override fun onDestroyView() {
+        super.onDestroyView()
+        takenSkippedChartView = null
+        takenSkippedTotalChartView = null
+        medicinesPerDayChartView = null
+    }
+
+    private fun setupTakenSkippedCharts(takenSkippedChartView: PieChart, takenSkippedTotalChartView: PieChart) {
         segmentTakenPeriod = Segment(requireContext().getString(R.string.taken), 0)
         segmentSkippedPeriod = Segment(requireContext().getString(R.string.skipped), 0)
         setupPieChart(takenSkippedChartView, segmentTakenPeriod, segmentSkippedPeriod)
@@ -188,13 +200,13 @@ class ChartsFragment : Fragment() {
         segment.title = "$stringValue: ${"%d%%".format(Locale.US, percentageValue)}"
     }
 
-    private fun setupMedicinesPerDayChart() {
+    private fun setupMedicinesPerDayChart(medicinesPerDayChartView: XYPlot) {
         try {
             medicinesPerDayChartView.setRangeLowerBoundary(0, BoundaryMode.FIXED)
-            setupBottomLine()
-            setupLeftLine()
-            setupNoBackgrounds()
-            setupLegend()
+            setupBottomLine(medicinesPerDayChartView)
+            setupLeftLine(medicinesPerDayChartView)
+            setupNoBackgrounds(medicinesPerDayChartView)
+            setupLegend(medicinesPerDayChartView)
             medicinesPerDayChartInitialized = true
         } catch (_: IllegalStateException) {
             // Intentionally ignored
@@ -207,20 +219,20 @@ class ChartsFragment : Fragment() {
         color = context.getMaterialColor(com.google.android.material.R.attr.colorOnSurface, "TakenSkippedChart")
     }
 
-    private fun setupBottomLine() {
+    private fun setupBottomLine(medicinesPerDayChartView: XYPlot) {
         val bottomLine = medicinesPerDayChartView.graph.getLineLabelStyle(XYGraphWidget.Edge.BOTTOM)
         bottomLine.format = DaysSinceEpochFormat()
         bottomLine.paint.textAlign = Paint.Align.CENTER
         bottomLine.paint.applyAxisLabelStyle()
     }
 
-    private fun setupLeftLine() {
+    private fun setupLeftLine(medicinesPerDayChartView: XYPlot) {
         val leftLine = medicinesPerDayChartView.graph.getLineLabelStyle(XYGraphWidget.Edge.LEFT)
         leftLine.format = DecimalFormat("#")
         leftLine.paint.applyAxisLabelStyle()
     }
 
-    private fun setupNoBackgrounds() {
+    private fun setupNoBackgrounds(medicinesPerDayChartView: XYPlot) {
         medicinesPerDayChartView.backgroundPaint = null
         medicinesPerDayChartView.graph.rangeGridLinePaint = null
         medicinesPerDayChartView.graph.domainGridLinePaint = null
@@ -232,7 +244,7 @@ class ChartsFragment : Fragment() {
         medicinesPerDayChartView.graph.rangeOriginLinePaint = null
     }
 
-    private fun setupLegend() {
+    private fun setupLegend(medicinesPerDayChartView: XYPlot) {
         val legend = medicinesPerDayChartView.legend
         legend.textPaint.applyAxisLabelStyle()
         legend.setPadding(requireContext().resources.dpToPx(4.0f), 0f, requireContext().resources.dpToPx(4.0f), 0f)
@@ -240,6 +252,7 @@ class ChartsFragment : Fragment() {
 
     private fun updateMedicinesPerDayChart(state: ChartsUiState) {
         if (!medicinesPerDayChartInitialized) return
+        val medicinesPerDayChartView = medicinesPerDayChartView ?: return
         val series = state.series
 
         medicinesPerDayChartView.clear()
@@ -262,7 +275,7 @@ class ChartsFragment : Fragment() {
             DynamicTableModel(numLegendColumns, 3, TableOrder.ROW_MAJOR)
         )
 
-        setupBarRenderer(state.domainMax - state.domainMin + 1)
+        setupBarRenderer(medicinesPerDayChartView, state.domainMax - state.domainMin + 1)
         medicinesPerDayChartView.redraw()
     }
 
@@ -286,7 +299,7 @@ class ChartsFragment : Fragment() {
         series.setTitle(title)
     }
 
-    private fun setupBarRenderer(numDomains: Long) {
+    private fun setupBarRenderer(medicinesPerDayChartView: XYPlot, numDomains: Long) {
         // The space between each bar and next to the outer bars is half bar width.
         // So we have numDomainsBar bars, numDomains - 1 spaces + 2 outer bars
         val numBars = numDomains + (numDomains - 1 + 2) / 2.0f

--- a/app/src/main/java/com/futsch1/medtimer/statistics/StatisticsFragment.kt
+++ b/app/src/main/java/com/futsch1/medtimer/statistics/StatisticsFragment.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 class StatisticsFragment : Fragment() {
     private val medicineViewModel: MedicineViewModel by viewModels()
     private val chartsViewModel: ChartsViewModel by viewModels()
-    private lateinit var timeSpinner: Spinner
+    private var timeSpinner: Spinner? = null
     private lateinit var chartsFragment: ChartsFragment
 
     @Inject
@@ -64,6 +64,11 @@ class StatisticsFragment : Fragment() {
         requireActivity().addMenuProvider(optionsMenu, getViewLifecycleOwner())
 
         return statisticsView
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        timeSpinner = null
     }
 
     override fun onPause() {
@@ -132,15 +137,15 @@ class StatisticsFragment : Fragment() {
 
     private fun checkTimeSpinnerVisibility() {
         if (persistentDataDataSource.data.value.activeStatisticsFragment == StatisticFragment.CHARTS) {
-            timeSpinner.visibility = View.VISIBLE
+            timeSpinner?.visibility = View.VISIBLE
         } else {
-            timeSpinner.visibility = View.INVISIBLE
+            timeSpinner?.visibility = View.INVISIBLE
         }
     }
 
     private fun setupTimeSpinner() {
-        timeSpinner.setSelection(AnalysisDays.getPosition(requireContext(), persistentDataDataSource.data.value.analysisDays))
-        timeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        timeSpinner?.setSelection(AnalysisDays.getPosition(requireContext(), persistentDataDataSource.data.value.analysisDays))
+        timeSpinner?.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(
                 parent: AdapterView<*>?,
                 view: View?,


### PR DESCRIPTION
Clear view references in onDestroyView() for ChartsFragment, StatisticsFragment, ReminderTableFragment and OverviewFragment to prevent retained references to destroyed views when fragments survive on the back stack.