### PR TITLE
Enable new dsl

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,4 @@ kotlin.code.style=official
 android.uniquePackageNames=false
 android.dependency.useConstraints=false
 android.r8.strictFullModeForKeepRules=false
-# Disable the new DSL until the SonarQube plugin was updated
-android.newDsl=false
+ksp.project.isolation.enabled=true


### PR DESCRIPTION
@Futsch1 this is a small one.
I've enabled the new DSL to silence the build warning.
I had no issues with building the app after this change.

AGP 10 will enforce new DSL and it is due to come out 'late 2026' so this change had to be made at some point.

Merge after #1441 