### PR TITLE
refactor: rename repository/DAO operator get() to fetch()

### DIFF
--- a/app/src/test/java/com/futsch1/medtimer/ReminderSummaryFormatterTest.kt
+++ b/app/src/test/java/com/futsch1/medtimer/ReminderSummaryFormatterTest.kt
@@ -122,10 +122,10 @@ class ReminderSummaryFormatterTest {
         var sourceReminder = Reminder.default()
         val sourceSourceReminder = Reminder.default()
         runBlocking {
-            `when`(mockReminderRepository[2]).thenReturn(sourceReminder)
+            `when`(mockReminderRepository.fetch(2)).thenReturn(sourceReminder)
         }
         runBlocking {
-            `when`(mockReminderRepository[3]).thenReturn(sourceSourceReminder)
+            `when`(mockReminderRepository.fetch(3)).thenReturn(sourceSourceReminder)
         }
 
         val reminder = Reminder.default().copy(linkedReminderId = 2)
@@ -136,7 +136,7 @@ class ReminderSummaryFormatterTest {
 
         sourceReminder = sourceReminder.copy(linkedReminderId = 3, time = ReminderTime(3, isDuration = true))
         runBlocking {
-            `when`(mockReminderRepository[2]).thenReturn(sourceReminder)
+            `when`(mockReminderRepository.fetch(2)).thenReturn(sourceReminder)
         }
         runBlocking {
             assertEquals("After reminder at 8:00 AM + 0:03", formatter.formatReminderSummary(reminder))
@@ -159,8 +159,8 @@ class ReminderSummaryFormatterTest {
         val reminder2 = Reminder.default().copy(id = 2, time = ReminderTime(63, isDuration = true), linkedReminderId = 1)
         val reminder3 = Reminder.default().copy(id = 3, time = ReminderTime(144, isDuration = true), linkedReminderId = 2)
 
-        `when`(mockReminderRepository[2]).thenReturn(reminder2)
-        `when`(mockReminderRepository[1]).thenReturn(reminder)
+        `when`(mockReminderRepository.fetch(2)).thenReturn(reminder2)
+        `when`(mockReminderRepository.fetch(1)).thenReturn(reminder)
 
         assertEquals(
             "3 reminders\n" +

--- a/app/src/test/java/com/futsch1/medtimer/processortests/NotificationProcessorTest.kt
+++ b/app/src/test/java/com/futsch1/medtimer/processortests/NotificationProcessorTest.kt
@@ -126,11 +126,11 @@ class NotificationProcessorTest {
 
             val parts = mutableListOf<ReminderNotificationPart>()
             for (i in reminderNotificationData.reminderIds.indices) {
-                val reminder = testReminderContext.repositoryFakes.reminderRepositoryMock.get(reminderNotificationData.reminderIds[i])
+                val reminder = testReminderContext.repositoryFakes.reminderRepositoryMock.fetch(reminderNotificationData.reminderIds[i])
                     ?: return null
-                val medicine = testReminderContext.repositoryFakes.medicineRepositoryMock.get(reminder.medicineRelId)
+                val medicine = testReminderContext.repositoryFakes.medicineRepositoryMock.fetch(reminder.medicineRelId)
                     ?: return null
-                val event = testReminderContext.repositoryFakes.reminderEventRepositoryMock.get(reminderNotificationData.reminderEventIds[i])
+                val event = testReminderContext.repositoryFakes.reminderEventRepositoryMock.fetch(reminderNotificationData.reminderEventIds[i])
                     ?: return null
                 parts.add(ReminderNotificationPart(reminder, event, medicine))
             }

--- a/app/src/test/java/com/futsch1/medtimer/processortests/TestReminderContext.kt
+++ b/app/src/test/java/com/futsch1/medtimer/processortests/TestReminderContext.kt
@@ -47,7 +47,7 @@ class RepositoryFakes {
     init {
         // MedicineRepository mocks
         `when`(runBlocking { medicineRepositoryMock.getAll() }).thenAnswer { buildMedicines() }
-        `when`(runBlocking { medicineRepositoryMock.get(anyInt()) }).thenAnswer { buildMedicines().firstOrNull { m -> m.id == it.arguments[0] } }
+        `when`(runBlocking { medicineRepositoryMock.fetch(anyInt()) }).thenAnswer { buildMedicines().firstOrNull { m -> m.id == it.arguments[0] } }
         `when`(runBlocking { medicineRepositoryMock.update(any()) }).thenAnswer {
             val medicine = it.arguments[0] as com.futsch1.medtimer.core.domain.model.Medicine
             val index = medicines.indexOfFirst { m -> m.medicineId == medicine.id }
@@ -55,11 +55,11 @@ class RepositoryFakes {
         }
 
         // ReminderRepository mocks
-        `when`(runBlocking { reminderRepositoryMock.get(anyInt()) }).thenAnswer { reminders.firstOrNull { r -> r.reminderId == it.arguments[0] }?.toModel() }
+        `when`(runBlocking { reminderRepositoryMock.fetch(anyInt()) }).thenAnswer { reminders.firstOrNull { r -> r.reminderId == it.arguments[0] }?.toModel() }
 
         // ReminderEventRepository mocks
         `when`(runBlocking { reminderEventRepositoryMock.getForScheduling(anyList()) }).thenAnswer { reminderEvents.map { it.toModel() } }
-        `when`(runBlocking { reminderEventRepositoryMock.get(anyInt()) }).thenAnswer {
+        `when`(runBlocking { reminderEventRepositoryMock.fetch(anyInt()) }).thenAnswer {
             reminderEvents.firstOrNull { r -> r.reminderEventId == it.arguments[0] }?.toModel()
         }
         `when`(runBlocking { reminderEventRepositoryMock.create(any()) }).thenAnswer {

--- a/core/database/src/main/java/com/futsch1/medtimer/database/MedicineRepositoryImpl.kt
+++ b/core/database/src/main/java/com/futsch1/medtimer/database/MedicineRepositoryImpl.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.map
 class MedicineRepositoryImpl(
     private val medicineDao: MedicineDao
 ) : MedicineRepository {
-    override suspend operator fun get(medicineId: Int): Medicine? {
+    override suspend fun fetch(medicineId: Int): Medicine? {
         return medicineDao.getFull(medicineId)?.toModel()
     }
 
@@ -32,7 +32,7 @@ class MedicineRepositoryImpl(
     }
 
     override suspend fun delete(medicineId: Int) {
-        medicineDao[medicineId]?.let { medicineDao.delete(it) }
+        medicineDao.fetch(medicineId)?.let { medicineDao.delete(it) }
     }
 
     override suspend fun update(medicine: Medicine) {

--- a/core/database/src/main/java/com/futsch1/medtimer/database/ReminderEventRepositoryImpl.kt
+++ b/core/database/src/main/java/com/futsch1/medtimer/database/ReminderEventRepositoryImpl.kt
@@ -65,16 +65,16 @@ class ReminderEventRepositoryImpl(
         reminderEventDao.createAll(reminderEvents.map { it.toEntity() })
     }
 
-    override suspend operator fun get(reminderEventId: Int): ReminderEvent? {
-        return reminderEventDao.get(reminderEventId)?.toModel()
+    override suspend fun fetch(reminderEventId: Int): ReminderEvent? {
+        return reminderEventDao.fetch(reminderEventId)?.toModel()
     }
 
     override fun getFlow(reminderEventId: Int): Flow<ReminderEvent?> {
         return reminderEventDao.getFlow(reminderEventId).map { it?.toModel() }
     }
 
-    override suspend operator fun get(reminderId: Int, remindedTimestamp: Long): ReminderEvent? {
-        return reminderEventDao[reminderId, remindedTimestamp]?.toModel()
+    override suspend fun fetch(reminderId: Int, remindedTimestamp: Long): ReminderEvent? {
+        return reminderEventDao.fetch(reminderId, remindedTimestamp)?.toModel()
     }
 
     override suspend fun update(reminderEvent: ReminderEvent) {

--- a/core/database/src/main/java/com/futsch1/medtimer/database/ReminderRepositoryImpl.kt
+++ b/core/database/src/main/java/com/futsch1/medtimer/database/ReminderRepositoryImpl.kt
@@ -21,8 +21,8 @@ class ReminderRepositoryImpl(
         return reminderDao.getAll(medicineId).map { it.toModel() }
     }
 
-    override suspend operator fun get(reminderId: Int): Reminder? {
-        return reminderDao[reminderId]?.toModel()
+    override suspend fun fetch(reminderId: Int): Reminder? {
+        return reminderDao.fetch(reminderId)?.toModel()
     }
 
     override fun getFlow(reminderId: Int): Flow<Reminder?> {
@@ -46,7 +46,7 @@ class ReminderRepositoryImpl(
     }
 
     override suspend fun delete(reminderId: Int) {
-        reminderDao[reminderId]?.let { reminderDao.delete(it) }
+        reminderDao.fetch(reminderId)?.let { reminderDao.delete(it) }
     }
 
     override suspend fun deleteAll() {

--- a/core/database/src/main/java/com/futsch1/medtimer/database/dao/MedicineDao.kt
+++ b/core/database/src/main/java/com/futsch1/medtimer/database/dao/MedicineDao.kt
@@ -15,7 +15,7 @@ abstract class MedicineDao {
 
     @Transaction
     open suspend fun decreaseStock(medicineId: Int, decreaseAmount: Double): FullMedicineEntity? {
-        val medicine = get(medicineId) ?: return null
+        val medicine = fetch(medicineId) ?: return null
         medicine.amount = maxOf(0.0, medicine.amount - decreaseAmount)
         update(medicine)
         return getFull(medicineId)
@@ -30,7 +30,7 @@ abstract class MedicineDao {
     abstract suspend fun getAll(): List<FullMedicineEntity>
 
     @Query("SELECT * FROM Medicine WHERE medicineId = :medicineId")
-    abstract suspend operator fun get(medicineId: Int): MedicineEntity?
+    abstract suspend fun fetch(medicineId: Int): MedicineEntity?
 
     @Transaction
     @Query("SELECT * FROM Medicine WHERE medicineId = :medicineId")

--- a/core/database/src/main/java/com/futsch1/medtimer/database/dao/ReminderDao.kt
+++ b/core/database/src/main/java/com/futsch1/medtimer/database/dao/ReminderDao.kt
@@ -18,7 +18,7 @@ interface ReminderDao {
     suspend fun getAll(medicineId: Int): List<ReminderEntity>
 
     @Query("SELECT * FROM Reminder WHERE reminderId = :reminderId")
-    suspend operator fun get(reminderId: Int): ReminderEntity?
+    suspend fun fetch(reminderId: Int): ReminderEntity?
 
     @Query("SELECT * FROM Reminder WHERE reminderId = :reminderId")
     fun getFlow(reminderId: Int): Flow<ReminderEntity?>

--- a/core/database/src/main/java/com/futsch1/medtimer/database/dao/ReminderEventDao.kt
+++ b/core/database/src/main/java/com/futsch1/medtimer/database/dao/ReminderEventDao.kt
@@ -20,7 +20,7 @@ interface ReminderEventDao {
     suspend fun getAllLimited(fromTimestamp: Long, statusValues: List<ReminderEntityStatus>): List<ReminderEventEntity>
 
     @Query("SELECT * FROM ReminderEvent WHERE reminderEventId = :reminderEventId")
-    suspend fun get(reminderEventId: Int): ReminderEventEntity?
+    suspend fun fetch(reminderEventId: Int): ReminderEventEntity?
 
     @Query("SELECT * FROM ReminderEvent WHERE reminderEventId = :reminderEventId")
     fun getFlow(reminderEventId: Int): Flow<ReminderEventEntity?>
@@ -35,7 +35,7 @@ interface ReminderEventDao {
     suspend fun getLastN(reminderId: Int, limit: Int): List<ReminderEventEntity>
 
     @Query("SELECT * FROM ReminderEvent WHERE reminderId = :reminderId AND remindedTimestamp = :remindedTimestamp")
-    suspend operator fun get(reminderId: Int, remindedTimestamp: Long): ReminderEventEntity?
+    suspend fun fetch(reminderId: Int, remindedTimestamp: Long): ReminderEventEntity?
 
     @Insert
     suspend fun create(reminderEvent: ReminderEventEntity): Long
@@ -57,7 +57,7 @@ interface ReminderEventDao {
 
     @Transaction
     suspend fun decreaseRepeats(reminderEventId: Int) {
-        val reminderEvent = get(reminderEventId) ?: return
+        val reminderEvent = fetch(reminderEventId) ?: return
         if (reminderEvent.remainingRepeats > 0) {
             reminderEvent.remainingRepeats -= 1
             update(reminderEvent)

--- a/core/domain/src/main/java/com/futsch1/medtimer/core/domain/repository/MedicineRepository.kt
+++ b/core/domain/src/main/java/com/futsch1/medtimer/core/domain/repository/MedicineRepository.kt
@@ -4,7 +4,7 @@ import com.futsch1.medtimer.core.domain.model.Medicine
 import kotlinx.coroutines.flow.Flow
 
 interface MedicineRepository {
-    suspend operator fun get(medicineId: Int): Medicine?
+    suspend fun fetch(medicineId: Int): Medicine?
     fun getFlow(medicineId: Int): Flow<Medicine?>
     suspend fun getAll(): List<Medicine>
     fun getAllFlow(): Flow<List<Medicine>>

--- a/core/domain/src/main/java/com/futsch1/medtimer/core/domain/repository/ReminderEventRepository.kt
+++ b/core/domain/src/main/java/com/futsch1/medtimer/core/domain/repository/ReminderEventRepository.kt
@@ -17,9 +17,9 @@ interface ReminderEventRepository {
     suspend fun getLast(reminderId: Int): ReminderEvent?
     suspend fun create(reminderEvent: ReminderEvent): ReminderEvent
     suspend fun createAll(reminderEvents: List<ReminderEvent>)
-    suspend operator fun get(reminderEventId: Int): ReminderEvent?
+    suspend fun fetch(reminderEventId: Int): ReminderEvent?
     fun getFlow(reminderEventId: Int): Flow<ReminderEvent?>
-    suspend operator fun get(reminderId: Int, remindedTimestamp: Long): ReminderEvent?
+    suspend fun fetch(reminderId: Int, remindedTimestamp: Long): ReminderEvent?
     suspend fun update(reminderEvent: ReminderEvent)
     suspend fun updateAll(reminderEvents: List<ReminderEvent>)
     suspend fun delete(reminderEvent: ReminderEvent)

--- a/core/domain/src/main/java/com/futsch1/medtimer/core/domain/repository/ReminderRepository.kt
+++ b/core/domain/src/main/java/com/futsch1/medtimer/core/domain/repository/ReminderRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface ReminderRepository {
     fun getAllFlow(medicineId: Int): Flow<List<Reminder>>
     suspend fun getAll(medicineId: Int): List<Reminder>
-    suspend operator fun get(reminderId: Int): Reminder?
+    suspend fun fetch(reminderId: Int): Reminder?
     fun getFlow(reminderId: Int): Flow<Reminder?>
     suspend fun getLinked(reminderId: Int): List<Reminder>
     suspend fun create(reminder: Reminder): Int

--- a/core/ui/src/main/java/com/futsch1/medtimer/core/ui/ReminderSummaryFormatter.kt
+++ b/core/ui/src/main/java/com/futsch1/medtimer/core/ui/ReminderSummaryFormatter.kt
@@ -124,11 +124,11 @@ class ReminderSummaryFormatter @Inject constructor(
 
     private suspend fun linkedReminderString(reminder: Reminder): String {
         val delays = mutableListOf<String>()
-        var current = reminderRepository[reminder.linkedReminderId] ?: return "?"
+        var current = reminderRepository.fetch(reminder.linkedReminderId) ?: return "?"
 
         while (current.reminderType == ReminderType.LINKED) {
             delays.add(timeFormatter.toTimeString(current.time))
-            current = reminderRepository[current.linkedReminderId] ?: return "?"
+            current = reminderRepository.fetch(current.linkedReminderId) ?: return "?"
         }
 
         val base = context.getString(
@@ -145,7 +145,7 @@ class ReminderSummaryFormatter @Inject constructor(
 
         while (current.reminderType == ReminderType.LINKED) {
             delays.add(timeFormatter.toTimeString(current.time))
-            val source = reminderRepository[current.linkedReminderId] ?: return "?"
+            val source = reminderRepository.fetch(current.linkedReminderId) ?: return "?"
             current = source
         }
 

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/NotificationProcessor.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/NotificationProcessor.kt
@@ -44,7 +44,7 @@ class NotificationProcessor @Inject constructor(
         Log.d(LogTags.REMINDER, "Process reminder events in notification $processedNotificationData")
         val reminderEventsToUpdate = mutableListOf<ReminderEvent>()
         for (reminderEventId in processedNotificationData.reminderEventIds) {
-            val reminderEvent = reminderEventRepository[reminderEventId]
+            val reminderEvent = reminderEventRepository.fetch(reminderEventId)
 
             if (reminderEvent != null) {
                 reminderEventsToUpdate.add(reminderEvent)
@@ -101,7 +101,7 @@ class NotificationProcessor @Inject constructor(
             return
         }
 
-        val remainingRepeats = reminderEventRepository[reminderNotificationData.reminderEventIds[0]]
+        val remainingRepeats = reminderEventRepository.fetch(reminderNotificationData.reminderEventIds[0])
             ?.remainingRepeats ?: return
 
         if (remainingRepeats != 0) {
@@ -144,7 +144,7 @@ class NotificationProcessor @Inject constructor(
         if (!reminderEvent.stockHandled && status == ReminderEvent.ReminderStatus.TAKEN ||
             reminderEvent.stockHandled && status == ReminderEvent.ReminderStatus.SKIPPED
         ) {
-            val reminder = reminderRepository[reminderEvent.reminderId] ?: return false
+            val reminder = reminderRepository.fetch(reminderEvent.reminderId) ?: return false
             var amount = MedicineHelper.parseAmount(reminderEvent.amount) ?: return false
             if (status == ReminderEvent.ReminderStatus.SKIPPED) {
                 amount = -amount

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/RefillProcessor.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/RefillProcessor.kt
@@ -20,8 +20,8 @@ class RefillProcessor @Inject constructor(
     private val timeAccess: TimeAccess
 ) {
     suspend fun processRefill(processedNotificationData: ProcessedNotificationData) {
-        val reminderEvent = reminderEventRepository[processedNotificationData.reminderEventIds[0]]
-        val reminder = reminderEvent?.let { reminderRepository[it.reminderId] }
+        val reminderEvent = reminderEventRepository.fetch(processedNotificationData.reminderEventIds[0])
+        val reminder = reminderEvent?.let { reminderRepository.fetch(it.reminderId) }
         reminder?.let { processRefill(it.medicineRelId, reminderEvent) }
 
     }
@@ -30,7 +30,7 @@ class RefillProcessor @Inject constructor(
         if (medicineId == null) {
             return
         }
-        val medicine = medicineRepository[medicineId] ?: return
+        val medicine = medicineRepository.fetch(medicineId) ?: return
 
         val refillEvent = processRefillInternal(medicine, medicineRepository)
         reminderEventRepository.create(refillEvent)

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationData/ReminderNotificationFactory.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationData/ReminderNotificationFactory.kt
@@ -29,22 +29,22 @@ open class ReminderNotificationFactory @Inject constructor(
         val numberOfRepeats = preferencesDataSource.preferences.value.numberOfRepetitions
         val newReminderEventIds = mutableListOf<Int>()
         for (i in reminderNotificationData.reminderIds.indices) {
-            val reminder = reminderRepository[reminderNotificationData.reminderIds[i]]
+            val reminder = reminderRepository.fetch(reminderNotificationData.reminderIds[i])
             if (reminder == null) {
                 Log.e(LogTags.REMINDER, String.format("Could not find reminder rID %d in database", reminderNotificationData.reminderIds[i]))
                 return null
             }
 
-            val medicine = medicineRepository[reminder.medicineRelId]
+            val medicine = medicineRepository.fetch(reminder.medicineRelId)
             if (medicine == null) {
                 Log.e(LogTags.REMINDER, "Could not find medicine mID ${reminder.medicineRelId} in database")
                 return null
             }
 
             var reminderEvent = if (reminderNotificationData.reminderEventIds[i] != 0) {
-                reminderEventRepository[reminderNotificationData.reminderEventIds[i]]
+                reminderEventRepository.fetch(reminderNotificationData.reminderEventIds[i])
             } else {
-                reminderEventRepository[reminder.id, reminderNotificationData.remindInstant.epochSecond]
+                reminderEventRepository.fetch(reminder.id, reminderNotificationData.remindInstant.epochSecond)
             }
 
             if (reminderEvent == null) {

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/EditMedicineFragment.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/EditMedicineFragment.kt
@@ -140,7 +140,7 @@ class EditMedicineFragment : Fragment(), IconDialog.Callback {
         setupSwiping(recyclerView)
 
         lifecycleScope.launch(ioDispatcher) {
-            val medicine = medicineRepository[getMedicineId()] ?: return@launch
+            val medicine = medicineRepository.fetch(getMedicineId()) ?: return@launch
 
             this@EditMedicineFragment.medicine = medicine
 
@@ -347,7 +347,7 @@ class EditMedicineFragment : Fragment(), IconDialog.Callback {
 
     private fun deleteItem(itemId: Long, adapterPosition: Int) {
         lifecycleScope.launch(ioDispatcher) {
-            val reminder = reminderRepository[itemId.toInt()]
+            val reminder = reminderRepository.fetch(itemId.toInt())
             if (reminder != null) {
                 withContext(mainDispatcher) {
                     linkedReminderHandlingFactory.create(reminder, lifecycleScope).deleteReminder(requireContext(), { }, {

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/EditMedicineMenuProvider.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/EditMedicineMenuProvider.kt
@@ -71,14 +71,14 @@ class EditMedicineMenuProvider @AssistedInject constructor(
     }
 
     private suspend fun assignTags(oldMedicineId: Int, newMedicineId: Int) {
-        val oldFullMedicine = medicineRepository[oldMedicineId] ?: return
+        val oldFullMedicine = medicineRepository.fetch(oldMedicineId) ?: return
         for (oldTag in oldFullMedicine.tags) {
             tagRepository.addMedicineTag(newMedicineId, oldTag.id)
         }
     }
 
     private suspend fun duplicateIncludingReminders() {
-        val fullMedicine = medicineRepository[medicine.id] ?: return
+        val fullMedicine = medicineRepository.fetch(medicine.id) ?: return
         val oldMedicineId = medicine.id
         val newMedicineId = medicineRepository.create(medicine.copy(id = 0))
         for (reminder in fullMedicine.reminders) {

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/MedicinesMenu.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/MedicinesMenu.kt
@@ -59,7 +59,7 @@ class MedicinesMenu @Inject constructor(
         applicationScope.launch {
             if (this@MedicinesMenu::medicines.isInitialized) {
                 for (medicine in medicines) {
-                    val localMedicine = medicineRepository[medicine.id] ?: return@launch
+                    val localMedicine = medicineRepository.fetch(medicine.id) ?: return@launch
                     setRemindersActive(localMedicine.reminders, reminderRepository, active)
                 }
             }

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/advancedReminderPreferences/AdvancedReminderPreferencesFragment.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/advancedReminderPreferences/AdvancedReminderPreferencesFragment.kt
@@ -28,7 +28,7 @@ abstract class AdvancedReminderPreferencesFragment(
         requireArguments: Bundle
     ): ModelDataStore<Reminder> {
         val modelDataId = requireArguments.getInt("reminderId")
-        val modelData = reminderRepository[modelDataId]!!
+        val modelData = reminderRepository.fetch(modelDataId)!!
 
         return reminderDataStoreFactory.create(modelData)
     }

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/advancedReminderPreferences/AdvancedReminderPreferencesStock.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/advancedReminderPreferences/AdvancedReminderPreferencesStock.kt
@@ -70,7 +70,7 @@ class AdvancedReminderPreferencesStockFragment : AdvancedReminderPreferencesFrag
         findPreference<Preference>("medicine_expiration_date")?.isVisible = modelData.reminderType == ReminderType.EXPIRATION_DATE
 
         this.lifecycleScope.launch(ioDispatcher) {
-            val medicine = medicineRepository[modelData.medicineRelId] ?: return@launch
+            val medicine = medicineRepository.fetch(modelData.medicineRelId) ?: return@launch
             this.launch(mainDispatcher) {
                 findPreference<Preference>("medicine_stock")?.summary =
                     MedicineHelper.formatAmount(medicine.amount, medicine.unit)

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/stockSettings/StockSettingsFragment.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/medicine/stockSettings/StockSettingsFragment.kt
@@ -94,7 +94,7 @@ class StockSettingsFragment : ModelDataPreferencesFragment<Medicine>(
 
     override suspend fun getDataStore(requireArguments: Bundle): ModelDataStore<Medicine> {
         val entityId = requireArguments.getInt("medicineId")
-        val entity = medicineRepository[entityId]!!
+        val entity = medicineRepository.fetch(entityId)!!
         return medicineDataStoreFactory.create(entity)
     }
 
@@ -152,7 +152,7 @@ class StockSettingsFragment : ModelDataPreferencesFragment<Medicine>(
         medicineId: Int,
         currentAmount: Double? = null
     ): LocalDate? {
-        var medicine = medicineRepository[medicineId] ?: return null
+        var medicine = medicineRepository.fetch(medicineId) ?: return null
 
         if (currentAmount != null) {
             medicine = medicine.copy(amount = currentAmount)

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/overview/ShowMedicineViewModel.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/overview/ShowMedicineViewModel.kt
@@ -53,12 +53,12 @@ class ShowMedicineViewModel @Inject constructor(
     init {
         val userPreferences = preferencesDataSource.preferences.value
         viewModelScope.launch(ioDispatcher) {
-            val reminder = reminderRepository[reminderId]
+            val reminder = reminderRepository.fetch(reminderId)
             if (reminder == null) {
                 _uiState.value = ShowMedicineUiState.NotFound
                 return@launch
             }
-            val medicine = medicineRepository[reminder.medicineRelId]
+            val medicine = medicineRepository.fetch(reminder.medicineRelId)
             if (medicine == null) {
                 _uiState.value = ShowMedicineUiState.NotFound
                 return@launch

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/overview/actions/ReminderEventActions.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/overview/actions/ReminderEventActions.kt
@@ -119,7 +119,7 @@ class ReminderEventActions @AssistedInject constructor(
 
     private suspend fun undoStock(reminderEvent: ReminderEvent) {
         val amount = MedicineHelper.parseAmount(reminderEvent.amount) ?: return
-        val reminder = reminderRepository[reminderEvent.reminderId] ?: return
+        val reminder = reminderRepository.fetch(reminderEvent.reminderId) ?: return
         medicineRepository.decreaseStock(reminder.medicineRelId, -amount)
     }
 

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/overview/actions/ReminderEventCreator.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/overview/actions/ReminderEventCreator.kt
@@ -20,12 +20,12 @@ class ReminderEventCreator @Inject constructor(
     private val timeFormatter: TimeFormatter,
 ) {
     suspend fun getOrCreateReminderEvent(scheduledReminder: ScheduledReminder, reminderTimeStamp: Long): ReminderEvent {
-        val existingReminderEvent = reminderEventRepository[scheduledReminder.reminder.id, scheduledReminder.timestamp.epochSecond]
+        val existingReminderEvent = reminderEventRepository.fetch(scheduledReminder.reminder.id, scheduledReminder.timestamp.epochSecond)
         if (existingReminderEvent != null) {
             return existingReminderEvent
         }
 
-        val reminder = reminderRepository[scheduledReminder.reminder.id] ?: scheduledReminder.reminder
+        val reminder = reminderRepository.fetch(scheduledReminder.reminder.id) ?: scheduledReminder.reminder
         val newReminderEvent = ReminderNotificationProcessor.buildReminderEvent(
             reminderTimeStamp, scheduledReminder.medicine, reminder, reminderEventRepository, timeFormatter
         )

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/statistics/CalendarEventsViewModel.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/statistics/CalendarEventsViewModel.kt
@@ -69,7 +69,7 @@ class CalendarEventsViewModel @Inject constructor(
             reminderEvents = reminderEventRepository.getLastDays(pastDays.toInt())
             allMedicines = medicineRepository.getAll()
             if (medicineId > 0) {
-                medicine = medicineRepository[medicineId]
+                medicine = medicineRepository.fetch(medicineId)
                 allMedicines =
                     allMedicines.filter { medicine -> medicine.id == medicineId }
             }


### PR DESCRIPTION
## Summary

- Replaces `operator fun get(id)` with `fun fetch(id)` on all repository interfaces (`MedicineRepository`, `ReminderRepository`, `ReminderEventRepository`) and DAO interfaces (`MedicineDao`, `ReminderDao`, `ReminderEventDao`)
- Updates all implementations and call sites (26 files total)
- Updates test mocks/stubs accordingly

## Motivation

The `operator fun get()` was introduced to satisfy SonarQube's naming rule, but it is not idiomatic Kotlin for this use case. Bracket-index syntax (`repo[id]`) implies simple in-memory indexing; these methods perform full Room database queries. `fetch()` communicates the intent clearly without SonarQube raising a naming issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)