### PR TITLE
Use dedicated notification channel for out-of-stock reminders

### DIFF
--- a/core/domain/src/main/java/com/futsch1/medtimer/core/domain/model/Medicine.kt
+++ b/core/domain/src/main/java/com/futsch1/medtimer/core/domain/model/Medicine.kt
@@ -29,6 +29,8 @@ data class Medicine(
     }
 
     enum class ReminderChannel(val channelId: String, val importance: Int) {
+        // "3" and "4" are legacy channel IDs from when the app used importance.toString() directly.
+        // Keeping them for backward compatibility so users don't lose their notification settings.
         DEFAULT("3", NotificationManager.IMPORTANCE_DEFAULT),
         HIGH("4", NotificationManager.IMPORTANCE_HIGH),
         OUT_OF_STOCK("out_of_stock", NotificationManager.IMPORTANCE_DEFAULT)

--- a/core/domain/src/main/java/com/futsch1/medtimer/core/domain/model/Medicine.kt
+++ b/core/domain/src/main/java/com/futsch1/medtimer/core/domain/model/Medicine.kt
@@ -28,6 +28,12 @@ data class Medicine(
         HIGH(NotificationManager.IMPORTANCE_HIGH)
     }
 
+    enum class ReminderChannel(val channelId: String, val importance: Int) {
+        DEFAULT("3", NotificationManager.IMPORTANCE_DEFAULT),
+        HIGH("4", NotificationManager.IMPORTANCE_HIGH),
+        OUT_OF_STOCK("out_of_stock", NotificationManager.IMPORTANCE_DEFAULT)
+    }
+
     fun hasExpired(): Boolean {
         return expirationDate != LocalDate.EPOCH && expirationDate < LocalDate.now()
     }

--- a/core/ui/src/main/res/values-ar/strings.xml
+++ b/core/ui/src/main/res/values-ar/strings.xml
@@ -193,6 +193,7 @@
     <string name="notification_importance">أولوية الإشعار</string>
     <string name="notification_settings_default">إعدادات الإشعار الأولوية الافتراضية</string>
     <string name="notification_settings_high">إعدادات الإشعار الأولوية المرتفعة</string>
+    <string name="notification_settings_out_of_stock">إعدادات تذكير نفاد المخزون</string>
     <string name="calendar">التقويم</string>
     <string name="date">التاريخ</string>
     <string name="active">نشط</string>

--- a/core/ui/src/main/res/values-bg/strings.xml
+++ b/core/ui/src/main/res/values-bg/strings.xml
@@ -168,6 +168,7 @@
     <string name="notification_importance">Приоритет на известието</string>
     <string name="notification_settings_default">Настройки на приоритета на известието по подразбиране</string>
     <string name="notification_settings_high">Настройка на висок приоритет на известието</string>
+    <string name="notification_settings_out_of_stock">Настройки на напомняне за отъствие на запас</string>
     <string name="calendar">Календар</string>
     <string name="date">Дата</string>
     <string name="active">Активно</string>

--- a/core/ui/src/main/res/values-cs/strings.xml
+++ b/core/ui/src/main/res/values-cs/strings.xml
@@ -182,6 +182,7 @@
     <string name="notification_importance">Priorita notifikací</string>
     <string name="notification_settings_default">Nastavení notifikací s výchozí prioritou</string>
     <string name="notification_settings_high">Nastavení notifikací s vysokou prioritou</string>
+    <string name="notification_settings_out_of_stock">Nastavení připomenutí vyčerpání zásob</string>
     <string name="calendar">Kalendář</string>
     <string name="date">Datum</string>
     <string name="active">Aktivní</string>

--- a/core/ui/src/main/res/values-da/strings.xml
+++ b/core/ui/src/main/res/values-da/strings.xml
@@ -166,6 +166,7 @@
     <string name="notification_importance">Notifikationsprioritet</string>
     <string name="notification_settings_default">Notifikationsindstillings standardprioritet</string>
     <string name="notification_settings_high">Notifikationsindstillings høj prioritet</string>
+    <string name="notification_settings_out_of_stock">Påmindelsesindstillinger for lav beholdning</string>
     <string name="calendar">Kalender</string>
     <string name="date">Dato</string>
     <string name="active">Aktiv</string>

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -169,6 +169,7 @@
     <string name="notification_importance">Benachrichtigungspriorität</string>
     <string name="notification_settings_default">Benachrichtigungseinstellungen Standardpriorität</string>
     <string name="notification_settings_high">Benachrichtigungseinstellungen hohe Priorität</string>
+    <string name="notification_settings_out_of_stock">Benachrichtigungseinstellungen Vorratserinnerung</string>
     <string name="calendar">Kalender</string>
     <string name="date">Date</string>
     <string name="active">Aktiv</string>

--- a/core/ui/src/main/res/values-el/strings.xml
+++ b/core/ui/src/main/res/values-el/strings.xml
@@ -169,6 +169,7 @@
     <string name="notification_importance">Προτεραιότητα ειδοποίησης</string>
     <string name="notification_settings_default">Ρύθμιση ειδοποιήσεων προεπιλεγμένης προτεραιότητας</string>
     <string name="notification_settings_high">Ρύθμιση ειδοποιήσεων υψηλής προτεραιότητας</string>
+    <string name="notification_settings_out_of_stock">Ρύθμιση υπενθύμισης εξάντλησης αποθέματος</string>
     <string name="calendar">Ημερολόγιο</string>
     <string name="date">Ημερομηνία</string>
     <string name="active">Ενεργή</string>

--- a/core/ui/src/main/res/values-es/strings.xml
+++ b/core/ui/src/main/res/values-es/strings.xml
@@ -175,6 +175,7 @@
     <string name="notification_importance">Prioridad de notificación</string>
     <string name="notification_settings_default">Ajustes de notificación de prioridad predeterminada</string>
     <string name="notification_settings_high">Ajustes de notificación de alta prioridad</string>
+    <string name="notification_settings_out_of_stock">Ajustes de recordatorio de existencias</string>
     <string name="calendar">Calendario</string>
     <string name="date">Fecha</string>
     <string name="active">Activo</string>

--- a/core/ui/src/main/res/values-fi/strings.xml
+++ b/core/ui/src/main/res/values-fi/strings.xml
@@ -170,6 +170,7 @@
     <string name="notification_importance">Ilmoituksen prioriteetti</string>
     <string name="notification_settings_default">Ilmoitusasetukset oletusprioriteetti</string>
     <string name="notification_settings_high">Ilmoitusasetukset korkea prioriteetti</string>
+    <string name="notification_settings_out_of_stock">Muistutusasetukset loppumisesta</string>
     <string name="calendar">Kalenteri</string>
     <string name="date">Päivämäärä</string>
     <string name="active">Aktiivinen</string>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -175,6 +175,7 @@
     <string name="notification_importance">Priorité de notification</string>
     <string name="notification_settings_default">Priorité par défaut des paramètres de notification</string>
     <string name="notification_settings_high">Paramètres de notification haute priorité</string>
+    <string name="notification_settings_out_of_stock">Paramètres de rappel de réserve épuisée</string>
     <string name="calendar">Calendrier</string>
     <string name="date">Date</string>
     <string name="active">Actif</string>

--- a/core/ui/src/main/res/values-hu/strings.xml
+++ b/core/ui/src/main/res/values-hu/strings.xml
@@ -170,6 +170,7 @@
     <string name="notification_importance">Értesítési prioritás</string>
     <string name="notification_settings_default">Alapértelmezett értesítési prioritás beállítása</string>
     <string name="notification_settings_high">Magas értesítési prioritás beállítása</string>
+    <string name="notification_settings_out_of_stock">Készletfigyelmeztetés beállítása</string>
     <string name="calendar">Naptár</string>
     <string name="date">Dátum</string>
     <string name="active">Aktív</string>

--- a/core/ui/src/main/res/values-is/strings.xml
+++ b/core/ui/src/main/res/values-is/strings.xml
@@ -145,6 +145,7 @@
     <string name="notification_importance">Forgangur tilkynninga</string>
     <string name="notification_settings_default">Sjálfgefinn forgangur tilkynninga</string>
     <string name="notification_settings_high">Tilkynningar með háan forgang</string>
+    <string name="notification_settings_out_of_stock">Tilkynningastillingar fyrir tómt lager</string>
     <string name="calendar">Dagatal</string>
     <string name="date">Dagur</string>
     <string name="active">Virk</string>

--- a/core/ui/src/main/res/values-it/strings.xml
+++ b/core/ui/src/main/res/values-it/strings.xml
@@ -175,6 +175,7 @@
     <string name="notification_importance">Priorità della notifica</string>
     <string name="notification_settings_default">Notifica con priorità predefinita</string>
     <string name="notification_settings_high">Notifica ad alta priorità</string>
+    <string name="notification_settings_out_of_stock">Impostazioni di promemoria esaurimento scorte</string>
     <string name="calendar">Calendario</string>
     <string name="date">Data</string>
     <string name="active">Attivo</string>

--- a/core/ui/src/main/res/values-iw/strings.xml
+++ b/core/ui/src/main/res/values-iw/strings.xml
@@ -172,6 +172,7 @@
     <string name="notification_importance">עדיפות התראה</string>
     <string name="notification_settings_default">עדיפות ברירת מחדל של הגדרות התראה</string>
     <string name="notification_settings_high">עדיפות גבוהה בהגדרות ההתראה</string>
+    <string name="notification_settings_out_of_stock">הגדרות תזכורת מחוץ למלאי</string>
     <string name="calendar">לוח שנה</string>
     <string name="date">תאריך</string>
     <string name="active">פעיל</string>

--- a/core/ui/src/main/res/values-nl/strings.xml
+++ b/core/ui/src/main/res/values-nl/strings.xml
@@ -169,6 +169,7 @@
     <string name="notification_importance">Prioriteit melding</string>
     <string name="notification_settings_default">Standaardprioriteit meldingsinstellingen</string>
     <string name="notification_settings_high">Meldingsinstellingen hoge prioriteit</string>
+    <string name="notification_settings_out_of_stock">Voorraadherinnering meldingsinstellingen</string>
     <string name="calendar">Kalender</string>
     <string name="date">Datum</string>
     <string name="active">Actief</string>

--- a/core/ui/src/main/res/values-pl/strings.xml
+++ b/core/ui/src/main/res/values-pl/strings.xml
@@ -232,6 +232,7 @@
     <string name="weeks_string">Tygodnie</string>
     <string name="intro_analysis_description">Aplikacja przechowuje wszystkie zdarzenia przypominające. Możesz analizować swoje poprzednie dawki na ekranie analizy i eksportować historię za pomocą menu kebab (trzy kropki). Historia zostanie zachowana, nawet jeśli leki lub przypomnienia zostaną usunięte lub przemianowane.</string>
     <string name="notification_settings_high">Wysoki priorytet</string>
+    <string name="notification_settings_out_of_stock">Ustawienia przypomnienia o wyczerpaniu zapasów</string>
     <string name="notification_settings_default">Domyślny priorytet</string>
     <string name="activate_all">Włącz wszystkie przypomnienia</string>
     <string name="override_dnd_summary">Odtwarza powiadomienia dźwiękowe, jeśli włączona jest tylko wibracja lub tryb nie przeszkadzać bez wibracji lub wyciszenia</string>

--- a/core/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/core/ui/src/main/res/values-pt-rBR/strings.xml
@@ -158,6 +158,7 @@
     <string name="notification_importance">Prioridade da notificação</string>
     <string name="notification_settings_default">Prioridade padrão das configurações de notificação</string>
     <string name="notification_settings_high">Configurações de notificação de alta prioridade</string>
+    <string name="notification_settings_out_of_stock">Configurações de lembrete de estoque esgotado</string>
     <string name="calendar">Calendário</string>
     <string name="date">Data</string>
     <string name="active">Ativo</string>

--- a/core/ui/src/main/res/values-pt/strings.xml
+++ b/core/ui/src/main/res/values-pt/strings.xml
@@ -158,6 +158,7 @@
     <string name="notification_importance">Prioridade da notificação</string>
     <string name="notification_settings_default">Prioridade padrão das configurações de notificação</string>
     <string name="notification_settings_high">Configurações de notificação de alta prioridade</string>
+    <string name="notification_settings_out_of_stock">Configurações de lembrete de estoque esgotado</string>
     <string name="calendar">Calendário</string>
     <string name="date">Data</string>
     <string name="active">Ativo</string>

--- a/core/ui/src/main/res/values-ru/strings.xml
+++ b/core/ui/src/main/res/values-ru/strings.xml
@@ -177,6 +177,7 @@
     <string name="notification_importance">Приоритет напоминаний</string>
     <string name="notification_settings_default">Настройки уведомлений стандартного приоритета</string>
     <string name="notification_settings_high">Настройки уведомлений высокого приоритета</string>
+    <string name="notification_settings_out_of_stock">Настройки напоминания об отсутствии на складе</string>
     <string name="calendar">Календарь</string>
     <string name="date">Дата</string>
     <string name="active">Активный</string>

--- a/core/ui/src/main/res/values-sv/strings.xml
+++ b/core/ui/src/main/res/values-sv/strings.xml
@@ -174,6 +174,7 @@
     <string name="notification_importance">Aviseringsprioritet</string>
     <string name="notification_settings_default">Standardprioritet för aviseringsinställningar</string>
     <string name="notification_settings_high">Aviseringsinställningar med hög prioritet</string>
+    <string name="notification_settings_out_of_stock">Påminnelseinställningar för slut i lager</string>
     <string name="calendar">Kalender</string>
     <string name="date">Datum</string>
     <string name="active">Aktiv</string>

--- a/core/ui/src/main/res/values-ta/strings.xml
+++ b/core/ui/src/main/res/values-ta/strings.xml
@@ -170,6 +170,7 @@
     <string name="notification_importance">அறிவிப்பு முன்னுரிமை</string>
     <string name="notification_settings_default">அறிவிப்பு அமைப்புகள் இயல்புநிலை முன்னுரிமை</string>
     <string name="notification_settings_high">அறிவிப்பு அமைப்புகள் அதிக முன்னுரிமை</string>
+    <string name="notification_settings_out_of_stock">இருப்பு நினைவூட்டல் அமைப்புகள்</string>
     <string name="calendar">நாட்காட்டி</string>
     <string name="date">திகதி</string>
     <string name="active">செயலில்</string>

--- a/core/ui/src/main/res/values-tr/strings.xml
+++ b/core/ui/src/main/res/values-tr/strings.xml
@@ -169,6 +169,7 @@
     <string name="notification_importance">Bildirim önceliği</string>
     <string name="notification_settings_default">Bildirim ayarları varsayılan öncelik</string>
     <string name="notification_settings_high">Bildirim ayarları yüksek öncelik</string>
+    <string name="notification_settings_out_of_stock">Bildirim ayarları stokta yok hatırlatması</string>
     <string name="calendar">Takvim</string>
     <string name="date">Tarih</string>
     <string name="active">Aktif</string>

--- a/core/ui/src/main/res/values-uk/strings.xml
+++ b/core/ui/src/main/res/values-uk/strings.xml
@@ -175,6 +175,7 @@
     <string name="notification_importance">Пріоритет сповіщення</string>
     <string name="notification_settings_default">Налаштування сповіщень за замовчуванням Пріоритет за замовчуванням</string>
     <string name="notification_settings_high">Налаштування сповіщень з високим пріоритетом</string>
+    <string name="notification_settings_out_of_stock">Налаштування нагадування про відсутність ліків</string>
     <string name="calendar">Календар</string>
     <string name="date">Дата</string>
     <string name="active">Активний</string>

--- a/core/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/core/ui/src/main/res/values-zh-rCN/strings.xml
@@ -163,6 +163,7 @@
     <string name="notification_importance">通知优先级</string>
     <string name="notification_settings_default">默认优先级通知设置</string>
     <string name="notification_settings_high">高优先级通知设置</string>
+    <string name="notification_settings_out_of_stock">库存不足提醒设置</string>
     <string name="calendar">日历</string>
     <string name="date">日期</string>
     <string name="active">启用提醒</string>

--- a/core/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/core/ui/src/main/res/values-zh-rTW/strings.xml
@@ -161,6 +161,7 @@
     <string name="are_you_sure_delete_reminder_event">您確定要刪除這個提醒事件嗎？</string>
     <string name="notification_settings_default">通知設定預設優先權</string>
     <string name="notification_settings_high">通知設定高優先權</string>
+    <string name="notification_settings_out_of_stock">庫存不足提醒設定</string>
     <string name="show_intro">顯示應用程式介紹</string>
     <string name="time_after">在藥品 y 之後 x 小時</string>
     <string name="intro_overview_description">在總覽畫面中，你可以查看即將到來的提醒以及最近的提醒事件。提醒事件可向右滑動進行編輯，向左滑動則可刪除。\n\n此外，你也可以手動記錄額外的劑量，無論是已設定的藥品或自訂藥品都可以。</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <string name="notification_importance">Notification priority</string>
     <string name="notification_settings_default">Notification settings default priority</string>
     <string name="notification_settings_high">Notification settings high priority</string>
+    <string name="notification_settings_out_of_stock">Notification settings out of stock</string>
     <string name="calendar">Calendar</string>
     <string name="date">Date</string>
     <string name="active">Active</string>

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/ReminderNotificationChannel.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/ReminderNotificationChannel.kt
@@ -3,12 +3,13 @@ package com.futsch1.medtimer.feature.reminders
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import com.futsch1.medtimer.core.domain.model.Medicine
 import com.futsch1.medtimer.core.ui.R
 
 class ReminderNotificationChannel(
     private val context: Context,
     private val notificationManager: NotificationManager,
-    private val importance: Int,
+    private val reminderChannel: Medicine.ReminderChannel,
     private val nameId: Int
 ) {
     val id: String
@@ -21,12 +22,12 @@ class ReminderNotificationChannel(
     }
 
     private fun getOrCreateChannel(): NotificationChannel {
-        return notificationManager.getNotificationChannel(importance.toString()) ?: createChannel()
+        return notificationManager.getNotificationChannel(reminderChannel.channelId) ?: createChannel()
     }
 
     private fun createChannel(): NotificationChannel {
         val notificationChannel =
-            NotificationChannel(importance.toString(), context.getString(nameId), importance)
+            NotificationChannel(reminderChannel.channelId, context.getString(nameId), reminderChannel.importance)
         notificationChannel.description = context.getString(R.string.notification_title)
 
         notificationManager.createNotificationChannel(notificationChannel)

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/ReminderNotificationChannelManager.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/ReminderNotificationChannelManager.kt
@@ -22,28 +22,34 @@ class ReminderNotificationChannelManager {
                 channelId++
             }
 
-            createChannel(context, notificationManager, Medicine.NotificationImportance.DEFAULT)
-            createChannel(context, notificationManager, Medicine.NotificationImportance.HIGH)
+            createChannel(context, notificationManager, Medicine.ReminderChannel.DEFAULT)
+            createChannel(context, notificationManager, Medicine.ReminderChannel.HIGH)
+            createChannel(context, notificationManager, Medicine.ReminderChannel.OUT_OF_STOCK)
         }
 
         fun getNotificationChannel(
             context: Context,
             notificationManager: NotificationManager,
-            notificationImportance: Medicine.NotificationImportance
+            reminderChannel: Medicine.ReminderChannel
         ): ReminderNotificationChannel {
-            return createChannel(context, notificationManager, notificationImportance)
+            return createChannel(context, notificationManager, reminderChannel)
         }
 
         private fun createChannel(
             context: Context,
             notificationManager: NotificationManager,
-            notificationImportance: Medicine.NotificationImportance
+            reminderChannel: Medicine.ReminderChannel
         ): ReminderNotificationChannel {
+            val nameId = when (reminderChannel) {
+                Medicine.ReminderChannel.HIGH -> R.string.high
+                Medicine.ReminderChannel.DEFAULT -> R.string.default_
+                Medicine.ReminderChannel.OUT_OF_STOCK -> R.string.out_of_stock_reminder
+            }
             return ReminderNotificationChannel(
                 context,
                 notificationManager,
-                notificationImportance.value,
-                if (notificationImportance == Medicine.NotificationImportance.HIGH) R.string.high else R.string.default_
+                reminderChannel,
+                nameId
             )
         }
     }

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationData/ReminderNotificationPart.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationData/ReminderNotificationPart.kt
@@ -31,3 +31,11 @@ fun List<ReminderNotificationPart>.effectiveHighestImportance(): Medicine.Notifi
     }
     return Medicine.NotificationImportance.DEFAULT
 }
+
+fun List<ReminderNotificationPart>.channelForHighestImportance(): Medicine.ReminderChannel {
+    for (part in this) {
+        if (part.effectiveImportance() == Medicine.NotificationImportance.HIGH)
+            return Medicine.ReminderChannel.HIGH
+    }
+    return Medicine.ReminderChannel.DEFAULT
+}

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationFactory/ExpirationDateNotificationFactory.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationFactory/ExpirationDateNotificationFactory.kt
@@ -30,7 +30,7 @@ class ExpirationDateNotificationFactory @AssistedInject constructor(
         reminderNotification.reminderNotificationData.notificationId,
         reminderNotification.reminderNotificationParts.map { it.medicine },
         notificationManager,
-        Medicine.NotificationImportance.DEFAULT
+        Medicine.ReminderChannel.DEFAULT
     ) {
 
     init {

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationFactory/NotificationFactory.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationFactory/NotificationFactory.kt
@@ -23,7 +23,7 @@ abstract class NotificationFactory(
     protected val notificationId: Int,
     medicines: List<Medicine>,
     notificationManager: NotificationManager,
-    importance: Medicine.NotificationImportance
+    reminderChannel: Medicine.ReminderChannel
 ) {
     val builder: NotificationCompat.Builder
 
@@ -31,7 +31,7 @@ abstract class NotificationFactory(
         val notificationChannelId = ReminderNotificationChannelManager.getNotificationChannel(
             context,
             notificationManager,
-            importance
+            reminderChannel
         ).id
         builder = NotificationCompat.Builder(context, notificationChannelId)
 

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationFactory/OutOfStockNotificationFactory.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationFactory/OutOfStockNotificationFactory.kt
@@ -29,7 +29,7 @@ class OutOfStockNotificationFactory @AssistedInject constructor(
         reminderNotification.reminderNotificationData.notificationId,
         reminderNotification.reminderNotificationParts.map { it.medicine },
         notificationManager,
-        Medicine.NotificationImportance.DEFAULT
+        Medicine.ReminderChannel.OUT_OF_STOCK
     ) {
 
     init {

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationFactory/ReminderNotificationFactory.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/notificationFactory/ReminderNotificationFactory.kt
@@ -13,7 +13,7 @@ import com.futsch1.medtimer.core.ui.R
 import com.futsch1.medtimer.core.ui.TimeFormatter
 import com.futsch1.medtimer.feature.reminders.alarm.ReminderAlarmActivity
 import com.futsch1.medtimer.feature.reminders.notificationData.ReminderNotification
-import com.futsch1.medtimer.feature.reminders.notificationData.effectiveHighestImportance
+import com.futsch1.medtimer.feature.reminders.notificationData.channelForHighestImportance
 import com.futsch1.medtimer.feature.reminders.notificationData.effectiveShowAsAlarm
 
 
@@ -31,7 +31,7 @@ abstract class ReminderNotificationFactory(
     reminderNotification.reminderNotificationData.notificationId,
     reminderNotification.reminderNotificationParts.map { it.medicine },
     notificationManager,
-    reminderNotification.reminderNotificationParts.effectiveHighestImportance()
+    reminderNotification.reminderNotificationParts.channelForHighestImportance()
 ) {
 
     val intents = intentsFactory.create(reminderNotification)

--- a/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/preferences/NotificationSettingsFragment.kt
+++ b/feature/ui/src/main/java/com/futsch1/medtimer/feature/ui/preferences/NotificationSettingsFragment.kt
@@ -65,12 +65,17 @@ class NotificationSettingsFragment : PreferencesFragment() {
         var preference =
             preferenceScreen.findPreference<Preference?>("notification_settings_high")
         if (preference != null) {
-            setupNotificationSettingsPreference(preference, Medicine.NotificationImportance.HIGH)
+            setupNotificationSettingsPreference(preference, Medicine.ReminderChannel.HIGH)
         }
         preference =
             preferenceScreen.findPreference("notification_settings_default")
         if (preference != null) {
-            setupNotificationSettingsPreference(preference, Medicine.NotificationImportance.DEFAULT)
+            setupNotificationSettingsPreference(preference, Medicine.ReminderChannel.DEFAULT)
+        }
+        preference =
+            preferenceScreen.findPreference("notification_settings_out_of_stock")
+        if (preference != null) {
+            setupNotificationSettingsPreference(preference, Medicine.ReminderChannel.OUT_OF_STOCK)
         }
         preferenceScreen.findPreference<Preference>(OVERRIDE_DND)?.onPreferenceChangeListener =
             Preference.OnPreferenceChangeListener { _, value ->
@@ -92,12 +97,12 @@ class NotificationSettingsFragment : PreferencesFragment() {
 
     private fun setupNotificationSettingsPreference(
         preference: Preference,
-        notificationImportance: Medicine.NotificationImportance
+        reminderChannel: Medicine.ReminderChannel
     ) {
         preference.onPreferenceClickListener = Preference.OnPreferenceClickListener { _ ->
             val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
             intent.putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().packageName)
-            intent.putExtra(Settings.EXTRA_CHANNEL_ID, notificationImportance.value.toString())
+            intent.putExtra(Settings.EXTRA_CHANNEL_ID, reminderChannel.channelId)
             startActivity(intent)
             true
         }

--- a/feature/ui/src/main/res/xml/notification_settings.xml
+++ b/feature/ui/src/main/res/xml/notification_settings.xml
@@ -15,6 +15,13 @@
         android:title="@string/notification_settings_high"
         app:singleLineTitle="false"
         app:key="notification_settings_high" />
+    <Preference
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:icon="@drawable/bell"
+        android:title="@string/notification_settings_out_of_stock"
+        app:singleLineTitle="false"
+        app:key="notification_settings_out_of_stock" />
     <SwitchPreferenceCompat
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #1479

Create a ReminderChannel enum to separate notification channel identity from importance level. This allows out-of-stock reminders to use their own Android notification channel ("out_of_stock") instead of sharing the default medicine reminder channel, enabling independent system-level settings (sound, vibration, visibility).

- Add ReminderChannel enum with DEFAULT, HIGH, and OUT_OF_STOCK
- Refactor ReminderNotificationChannel to use ReminderChannel
- Update OutOfStockNotificationFactory to use OUT_OF_STOCK channel
- Add notification settings preference for out-of-stock channel

Note: Translations for notification_settings_out_of_stock are machine- generated and may require native speaker review.