### PR TITLE
Fix number format exception crashes and backup directory handling in PreferencesDataSource

### DIFF
--- a/core/datastore/src/main/java/com/futsch1/medtimer/core/datastore/PreferencesDataSource.kt
+++ b/core/datastore/src/main/java/com/futsch1/medtimer/core/datastore/PreferencesDataSource.kt
@@ -67,7 +67,11 @@ class PreferencesDataSource @Inject constructor(
 
     private fun getHomeLocation(): HomeLocation? {
         val json = sharedPreferences.getString(HOME_LOCATION, null) ?: return null
-        return gson.fromJson(json, HomeLocation::class.java)
+        return try {
+            gson.fromJson(json, HomeLocation::class.java)
+        } catch (_: Exception) {
+            null
+        }
     }
 
     fun clearHomeLocation() {
@@ -142,19 +146,19 @@ class PreferencesDataSource @Inject constructor(
                 NUMBER_OF_REPETITIONS,
                 default.numberOfRepetitions.toString()
             )
-                ?.toInt()
+                ?.toIntOrNull()
                 ?: 3,
             repeatDelay = (sharedPreferences.getString(
                 REPEAT_DELAY,
                 default.repeatDelay.inWholeMinutes.toString()
             )
-                ?.toInt()
+                ?.toIntOrNull()
                 ?: 10).toDuration(DurationUnit.MINUTES),
             snoozeDuration = (sharedPreferences.getString(
                 SNOOZE_DURATION,
                 default.snoozeDuration.inWholeMinutes.toString()
             )
-                ?.toInt()
+                ?.toIntOrNull()
                 ?: 15).toDuration(DurationUnit.MINUTES),
             overrideDnd = sharedPreferences.getBoolean(OVERRIDE_DND, default.overrideDnd),
             stickyOnLockscreen = sharedPreferences.getBoolean(
@@ -204,7 +208,7 @@ class PreferencesDataSource @Inject constructor(
             ),
             useSecureWindow = sharedPreferences.getBoolean(SECURE_WINDOW, default.useSecureWindow),
             disableWidget = sharedPreferences.getBoolean(DISABLE_WIDGET, default.disableWidget),
-            alarmRingtone = sharedPreferences.getString(ALARM_RINGTONE, null)?.toUri()
+            alarmRingtone = sharedPreferences.getString(ALARM_RINGTONE, null)?.takeIf { it.isNotEmpty() }?.toUri()
                 ?: default.alarmRingtone,
             noAlarmSoundWhenSilent = sharedPreferences.getBoolean(
                 NO_ALARM_SOUND_WHEN_SILENT,
@@ -226,8 +230,8 @@ class PreferencesDataSource @Inject constructor(
                 },
             automaticBackupDirectory = sharedPreferences.getString(
                 AUTOMATIC_BACKUP_DIRECTORY,
-                default.automaticBackupDirectory.toString()
-            )?.toUri(),
+                null
+            )?.takeIf { it.isNotEmpty() }?.toUri(),
             locationBasedSnooze = sharedPreferences.getBoolean(
                 LOCATION_SNOOZE_ENABLED,
                 default.locationBasedSnooze

--- a/core/datastore/src/main/java/com/futsch1/medtimer/core/datastore/PreferencesDataSource.kt
+++ b/core/datastore/src/main/java/com/futsch1/medtimer/core/datastore/PreferencesDataSource.kt
@@ -67,11 +67,9 @@ class PreferencesDataSource @Inject constructor(
 
     private fun getHomeLocation(): HomeLocation? {
         val json = sharedPreferences.getString(HOME_LOCATION, null) ?: return null
-        return try {
+        return runCatching {
             gson.fromJson(json, HomeLocation::class.java)
-        } catch (_: Exception) {
-            null
-        }
+        }.getOrNull()
     }
 
     fun clearHomeLocation() {


### PR DESCRIPTION
## Summary

Fixes **4 bugs** in `PreferencesDataSource.kt` that caused crashes or incorrect behaviour when stored preference values are invalid. These bugs were discovered and documented by the test suite in [PR #1590](https://github.com/Futsch1/medTimer/pull/1590).

## Changes

### 1. NumberFormatException on invalid stored integers (3 locations)

`numberOfRepetitions`, `repeatDelay`, and `snoozeDuration` were parsed with `?.toInt()`, which throws `NumberFormatException` when the stored preference value is not a valid integer (e.g. corrupt data after a failed backup restore).

**Fix:** replaced with `?.toIntOrNull()` — returns `null` for invalid input, falling back to the default value.

### 2. Backup directory default produces wrong URI

`default.automaticBackupDirectory` is `null`, but the code called `.toString()` on it, producing the literal string `"null"`. This was then parsed by `.toUri()` → `Uri.parse("null")`, returning a non-null "null" URI instead of `null`.

**Fix:** changed the default to `null` directly.

### 3. Empty strings not handled before URI parsing (2 locations)

Both `alarmRingtone` and `automaticBackupDirectory` called `?.toUri()` directly on the stored string. An empty string `""` passes the null-safe call and produces a non-null empty URI, making it indistinguishable from "not set".

**Fix:** added `.takeIf { it.isNotEmpty() }` before `.toUri()`.

### 4. JsonSyntaxException crash on corrupt home location JSON

`getHomeLocation()` calls `gson.fromJson()` without any error handling. If the stored JSON is corrupt (e.g. partial write), the app crashes on every startup — this is a critical stability issue.

**Fix:** wrapped deserialization in try-catch, returning `null` on failure.

## Verification

- Compiles cleanly: ✅
- App builds (full + foss): ✅
- Existing app unit tests (257): ✅ all pass
- When merged with the test PR branch: all 141 datastore tests pass ✅

_Note: AI assistance was used in drafting this code and/or tests._