### PR TITLE
Migrate main screen warning cards to compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,6 +135,7 @@ dependencies {
     implementation(libs.androidx.compose.material3.adaptive)
     implementation(libs.androidx.compose.material3.adaptive.navigation.suite)
     implementation(libs.androidx.compose.ui.viewbinding)
+    implementation(libs.androidx.compose.ui.tooling.preview)
     debugImplementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.service)

--- a/app/src/main/java/com/futsch1/medtimer/AppNavigation.kt
+++ b/app/src/main/java/com/futsch1/medtimer/AppNavigation.kt
@@ -1,5 +1,12 @@
 package com.futsch1.medtimer
 
+import androidx.appcompat.widget.Toolbar
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
@@ -7,6 +14,7 @@ import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -25,6 +33,7 @@ import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.fragment.NavHostFragment
 import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
 import com.futsch1.medtimer.databinding.ContentMainBinding
+import com.futsch1.medtimer.databinding.ToolbarBinding
 import com.futsch1.medtimer.core.ui.R as CoreUiR
 import com.futsch1.medtimer.feature.ui.R as FeatureUiR
 
@@ -48,6 +57,13 @@ fun navSuiteType(windowAdaptiveInfo: WindowAdaptiveInfo): NavigationSuiteType =
         NavigationSuiteType.NavigationBar
     }
 
+/**
+ * Whether the shell content has to pad the bottom system-bar inset itself. The NavigationBar consumes
+ * it; the rail sits on the side and leaves the gesture bar to the content.
+ */
+fun consumesBottomInset(navigationSuiteType: NavigationSuiteType): Boolean =
+    navigationSuiteType == NavigationSuiteType.NavigationRail
+
 private data class TopLevelNavItem(
     val destinationId: Int,
     val iconRes: Int,
@@ -70,17 +86,37 @@ private fun topLevelDestinationId(destination: NavDestination): Int =
     destination.hierarchy.firstOrNull { it.id in TOP_LEVEL_IDS }?.id ?: 0
 
 /**
- * Top-level navigation as an adaptive bar/rail. The Toolbar, warnings and the Fragment NavHost stay as
- * Views, embedded via AndroidViewBinding; [onContentBound] hands them back to the activity for wiring
- * (support action bar, warning buttons). Selection follows the NavController's current destination.
+ * Top-level navigation as an adaptive bar/rail. The Toolbar and the Fragment NavHost stay as Views,
+ * embedded either side of the Compose [Warnings]; [onContentBound] hands them back to the activity
+ * for wiring. Selection follows the NavController's current destination.
  */
 @Composable
 fun AppNavigationScaffold(
-    onContentBound: (ContentMainBinding, NavHostFragment) -> Unit,
+    state: MainScreenState,
+    onDismissBatteryWarning: () -> Unit,
+    onDismissExactRemindersWarning: () -> Unit,
+    onContentBound: (Toolbar, NavHostFragment) -> Unit,
     onNavItemClick: (NavController, Int) -> Unit,
 ) {
     var navController by remember { mutableStateOf<NavController?>(null) }
     var currentDestinationId by remember { mutableIntStateOf(0) }
+    var toolbar by remember { mutableStateOf<Toolbar?>(null) }
+    var navHostFragment by remember { mutableStateOf<NavHostFragment?>(null) }
+
+    // Wire once both nodes exist rather than relying on Column's top-down order: setSupportActionBar
+    // must precede setupActionBarWithNavController, and getting that backwards fails silently.
+    LaunchedEffect(toolbar, navHostFragment) {
+        val boundToolbar = toolbar ?: return@LaunchedEffect
+        val boundNavHost = navHostFragment ?: return@LaunchedEffect
+        onContentBound(boundToolbar, boundNavHost)
+    }
+
+    val navigationSuiteType = navSuiteType(currentWindowAdaptiveInfo())
+    val insetSides = if (consumesBottomInset(navigationSuiteType)) {
+        WindowInsetsSides.Top + WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+    } else {
+        WindowInsetsSides.Top + WindowInsetsSides.Horizontal
+    }
 
     NavigationSuiteScaffold(
         navigationSuiteItems = {
@@ -94,19 +130,29 @@ fun AppNavigationScaffold(
                 )
             }
         },
-        layoutType = navSuiteType(currentWindowAdaptiveInfo()),
+        layoutType = navigationSuiteType,
         modifier = Modifier.semantics { testTagsAsResourceId = true },
     ) {
-        AndroidViewBinding(ContentMainBinding::inflate) {
-            // The update block runs on every recomposition; set up exactly once.
-            if (navController == null) {
-                val navHostFragment = navHost.getFragment<NavHostFragment>()
-                val controller = navHostFragment.navController
-                controller.addOnDestinationChangedListener { _, destination, _ ->
-                    currentDestinationId = topLevelDestinationId(destination)
+        Column(Modifier.windowInsetsPadding(WindowInsets.systemBars.only(insetSides))) {
+            AndroidViewBinding(ToolbarBinding::inflate) {
+                toolbar = root
+            }
+            Warnings(
+                state = state,
+                onDismissBatteryWarning = onDismissBatteryWarning,
+                onDismissExactRemindersWarning = onDismissExactRemindersWarning,
+            )
+            AndroidViewBinding(ContentMainBinding::inflate, Modifier.weight(1f)) {
+                // The update block runs on every recomposition; set up exactly once.
+                if (navController == null) {
+                    val fragment = root.getFragment<NavHostFragment>()
+                    val controller = fragment.navController
+                    controller.addOnDestinationChangedListener { _, destination, _ ->
+                        currentDestinationId = topLevelDestinationId(destination)
+                    }
+                    navController = controller
+                    navHostFragment = fragment
                 }
-                navController = controller
-                onContentBound(this, navHostFragment)
             }
         }
     }

--- a/app/src/main/java/com/futsch1/medtimer/MainActivity.kt
+++ b/app/src/main/java/com/futsch1/medtimer/MainActivity.kt
@@ -13,12 +13,12 @@ import android.os.Handler
 import android.os.PowerManager
 import android.text.InputType
 import android.util.Log
-import android.view.View
 import android.view.WindowManager
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.cardview.widget.CardView
+import androidx.appcompat.widget.Toolbar
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.content.ContextCompat
@@ -40,7 +40,6 @@ import com.futsch1.medtimer.core.datastore.PreferencesDataSource
 import com.futsch1.medtimer.core.domain.model.ThemeSetting
 import com.futsch1.medtimer.core.ui.theme.MedTimerTheme
 import com.futsch1.medtimer.database.backup.BackupManager
-import com.futsch1.medtimer.databinding.ContentMainBinding
 import com.futsch1.medtimer.feature.reminders.ReminderNotificationChannelManager.Companion.initialize
 import com.futsch1.medtimer.feature.reminders.ReminderSchedulerService
 import com.futsch1.medtimer.feature.reminders.api.command.ReminderCommandBus
@@ -60,9 +59,8 @@ class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var autostartService: AutostartService
     private var appBarConfiguration: AppBarConfiguration? = null
-    private var batteryOptimizationWarning: CardView? = null
-    private var exactReminderWarning: CardView? = null
     private var navHostFragment: NavHostFragment? = null
+    private val mainViewModel: MainViewModel by viewModels()
     private val requestNotificationPermission = RequestPostNotificationPermission(this) { persistentDataDataSource.setShowNotifications(false) }
 
     @Inject
@@ -167,6 +165,9 @@ class MainActivity : AppCompatActivity() {
                 setContent {
                     MedTimerTheme {
                         AppNavigationScaffold(
+                            state = mainViewModel.state,
+                            onDismissBatteryWarning = mainViewModel::dismissBatteryWarning,
+                            onDismissExactRemindersWarning = mainViewModel::dismissExactRemindersWarning,
                             onContentBound = ::onContentBound,
                             onNavItemClick = ::onNavItemClick,
                         )
@@ -195,7 +196,7 @@ class MainActivity : AppCompatActivity() {
         this.onBackPressedDispatcher.addCallback(this, backPressedCallback)
     }
 
-    private fun onContentBound(binding: ContentMainBinding, navHostFragment: NavHostFragment) {
+    private fun onContentBound(toolbar: Toolbar, navHostFragment: NavHostFragment) {
         this.navHostFragment = navHostFragment
         val navController = navHostFragment.navController
         // Track the tab whose area we're in. Detail screens (e.g. editMedicineFragment) are flat siblings
@@ -206,24 +207,13 @@ class MainActivity : AppCompatActivity() {
                 currentTabId = destination.id
             }
         }
-        setSupportActionBar(binding.toolbar)
+        setSupportActionBar(toolbar)
         appBarConfiguration = AppBarConfiguration.Builder(
             com.futsch1.medtimer.feature.ui.R.id.overviewFragment,
             com.futsch1.medtimer.feature.ui.R.id.medicinesFragment,
             com.futsch1.medtimer.feature.ui.R.id.statisticsFragment
         ).build()
         setupActionBarWithNavController(this, navController, appBarConfiguration!!)
-
-        batteryOptimizationWarning = binding.batteryOptimizationWarning
-        binding.dismissBatteryWarning.setOnClickListener {
-            persistentDataDataSource.setBatteryWarningShown(true)
-            checkBatteryOptimization()
-        }
-        exactReminderWarning = binding.exactRemindersWarning
-        binding.dismissExactReminderWarning.setOnClickListener {
-            persistentDataDataSource.setExactRemindersWarningShown(true)
-            checkExactReminders()
-        }
     }
 
     private val topLevelTabIds = setOf(
@@ -276,24 +266,6 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun checkBatteryOptimization() {
-        if (!powerManager.isIgnoringBatteryOptimizations(packageName) && !persistentDataDataSource.data.value.batteryWarningShown && !BuildConfig.DEBUG) {
-            Log.d(LogTags.MAIN, "Show battery optimization")
-            batteryOptimizationWarning?.visibility = View.VISIBLE
-        } else {
-            batteryOptimizationWarning?.visibility = View.GONE
-        }
-    }
-
-    private fun checkExactReminders() {
-        if (!preferencesDataSource.preferences.value.exactReminders && !persistentDataDataSource.data.value.exactRemindersWarningShown && !BuildConfig.DEBUG) {
-            Log.d(LogTags.MAIN, "Show exact reminders warning")
-            exactReminderWarning?.visibility = View.VISIBLE
-        } else {
-            exactReminderWarning?.visibility = View.GONE
-        }
-    }
-
     private suspend fun checkForceStopped() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val exitInfos: List<ApplicationExitInfo> = activityManager.getHistoricalProcessExitReasons(null, 0, 1)
@@ -320,8 +292,7 @@ class MainActivity : AppCompatActivity() {
 
         backupManagerFactory.create(this, this, null, null, null, supportFragmentManager).autoBackup()
 
-        checkBatteryOptimization()
-        checkExactReminders()
+        mainViewModel.refresh()
     }
 
     private suspend fun dispatchIntent(intent: Intent) {

--- a/app/src/main/java/com/futsch1/medtimer/MainScreenState.kt
+++ b/app/src/main/java/com/futsch1/medtimer/MainScreenState.kt
@@ -1,0 +1,28 @@
+package com.futsch1.medtimer
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/** See `docs/guidelines/jetpack-compose.md` §State holders. [MainViewModel] is the only writer. */
+interface MainScreenState {
+    val showBatteryOptimizationWarning: Boolean
+    val showExactRemindersWarning: Boolean
+}
+
+class MutableMainScreenState : MainScreenState {
+    override var showBatteryOptimizationWarning by mutableStateOf(false)
+    override var showExactRemindersWarning by mutableStateOf(false)
+}
+
+internal fun showBatteryOptimizationWarning(
+    warningsSuppressed: Boolean,
+    isIgnoringBatteryOptimizations: Boolean,
+    batteryWarningShown: Boolean,
+): Boolean = !warningsSuppressed && !batteryWarningShown && !isIgnoringBatteryOptimizations
+
+internal fun showExactRemindersWarning(
+    warningsSuppressed: Boolean,
+    exactReminders: Boolean,
+    exactRemindersWarningShown: Boolean,
+): Boolean = !warningsSuppressed && !exactRemindersWarningShown && !exactReminders

--- a/app/src/main/java/com/futsch1/medtimer/MainViewModel.kt
+++ b/app/src/main/java/com/futsch1/medtimer/MainViewModel.kt
@@ -1,0 +1,66 @@
+package com.futsch1.medtimer
+
+import android.content.Context
+import android.os.PowerManager
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.futsch1.medtimer.core.datastore.PersistentDataDataSource
+import com.futsch1.medtimer.core.datastore.PreferencesDataSource
+import com.futsch1.medtimer.di.IsDebugBuild
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+/**
+ * Drives the main screen. Following `docs/guidelines/jetpack-compose.md` §State holders, the
+ * view-model owns a [MutableMainScreenState] and exposes only the read-only [state].
+ *
+ * [PowerManager.isIgnoringBatteryOptimizations] is a synchronous query with no change notification —
+ * the user grants the exemption in system settings and returns — so [refresh] must also be called
+ * from `onResume`, not just on flow emissions.
+ */
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val preferencesDataSource: PreferencesDataSource,
+    private val persistentDataDataSource: PersistentDataDataSource,
+    private val powerManager: PowerManager,
+    @param:ApplicationContext private val context: Context,
+    @param:IsDebugBuild private val isDebugBuild: Boolean,
+) : ViewModel() {
+
+    private val _state = MutableMainScreenState()
+    val state: MainScreenState get() = _state
+
+    init {
+        combine(preferencesDataSource.preferences, persistentDataDataSource.data) { _, _ -> }
+            .onEach { refresh() }
+            .launchIn(viewModelScope)
+    }
+
+    fun refresh() {
+        val persistentData = persistentDataDataSource.data.value
+        _state.showBatteryOptimizationWarning = showBatteryOptimizationWarning(
+            warningsSuppressed = isDebugBuild,
+            isIgnoringBatteryOptimizations = powerManager.isIgnoringBatteryOptimizations(context.packageName),
+            batteryWarningShown = persistentData.batteryWarningShown,
+        )
+        _state.showExactRemindersWarning = showExactRemindersWarning(
+            warningsSuppressed = isDebugBuild,
+            exactReminders = preferencesDataSource.preferences.value.exactReminders,
+            exactRemindersWarningShown = persistentData.exactRemindersWarningShown,
+        )
+    }
+
+    fun dismissBatteryWarning() {
+        persistentDataDataSource.setBatteryWarningShown(true)
+        refresh()
+    }
+
+    fun dismissExactRemindersWarning() {
+        persistentDataDataSource.setExactRemindersWarningShown(true)
+        refresh()
+    }
+}

--- a/app/src/main/java/com/futsch1/medtimer/Warnings.kt
+++ b/app/src/main/java/com/futsch1/medtimer/Warnings.kt
@@ -1,0 +1,140 @@
+package com.futsch1.medtimer
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.futsch1.medtimer.core.ui.theme.MedTimerTheme
+import com.futsch1.medtimer.core.ui.R as CoreUiR
+
+/**
+ * The shell's dismissible warning cards. [MainViewModel] gates both on release builds, so the
+ * previews below are the only way to see them without building a release APK.
+ */
+@Composable
+fun Warnings(
+    state: MainScreenState,
+    onDismissBatteryWarning: () -> Unit,
+    onDismissExactRemindersWarning: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        AnimatedVisibility(
+            visible = state.showBatteryOptimizationWarning,
+            enter = EnterTransition.None,
+            exit = dismissTransition,
+        ) {
+            WarningCard(
+                titleRes = CoreUiR.string.battery_optimization_warning_title,
+                summaryRes = CoreUiR.string.battery_optimization_warning_summary,
+                onDismiss = onDismissBatteryWarning,
+            )
+        }
+        AnimatedVisibility(
+            visible = state.showExactRemindersWarning,
+            enter = EnterTransition.None,
+            exit = dismissTransition,
+        ) {
+            WarningCard(
+                titleRes = CoreUiR.string.exact_reminders_warning_title,
+                summaryRes = CoreUiR.string.exact_reminders_warning_summary,
+                onDismiss = onDismissExactRemindersWarning,
+            )
+        }
+    }
+}
+
+private const val FADE_MS = 150
+private const val COLLAPSE_MS = 200
+
+private val dismissTransition: ExitTransition
+    get() = fadeOut(tween(FADE_MS)) +
+            shrinkVertically(
+                animationSpec = tween(COLLAPSE_MS, delayMillis = FADE_MS),
+                shrinkTowards = Alignment.Top,
+            )
+
+@Composable
+private fun WarningCard(
+    titleRes: Int,
+    summaryRes: Int,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Text(
+                text = stringResource(titleRes),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+            Text(
+                text = stringResource(summaryRes),
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text(
+                    text = stringResource(CoreUiR.string.ok),
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+        }
+    }
+}
+
+private class PreviewMainScreenState(
+    override val showBatteryOptimizationWarning: Boolean,
+    override val showExactRemindersWarning: Boolean,
+) : MainScreenState
+
+@Preview(name = "Warnings — both")
+@Composable
+private fun WarningsBothPreview() {
+    MedTimerTheme {
+        Warnings(
+            state = PreviewMainScreenState(showBatteryOptimizationWarning = true, showExactRemindersWarning = true),
+            onDismissBatteryWarning = {},
+            onDismissExactRemindersWarning = {},
+        )
+    }
+}
+
+@Preview(name = "Warnings — exact reminders only")
+@Composable
+private fun WarningsExactRemindersPreview() {
+    MedTimerTheme {
+        Warnings(
+            state = PreviewMainScreenState(showBatteryOptimizationWarning = false, showExactRemindersWarning = true),
+            onDismissBatteryWarning = {},
+            onDismissExactRemindersWarning = {},
+        )
+    }
+}

--- a/app/src/main/java/com/futsch1/medtimer/di/BuildConfigModule.kt
+++ b/app/src/main/java/com/futsch1/medtimer/di/BuildConfigModule.kt
@@ -1,0 +1,15 @@
+package com.futsch1.medtimer.di
+
+import com.futsch1.medtimer.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object BuildConfigModule {
+    @Provides
+    @IsDebugBuild
+    fun provideIsDebugBuild(): Boolean = BuildConfig.DEBUG
+}

--- a/app/src/main/java/com/futsch1/medtimer/di/IsDebugBuild.kt
+++ b/app/src/main/java/com/futsch1/medtimer/di/IsDebugBuild.kt
@@ -1,0 +1,11 @@
+package com.futsch1.medtimer.di
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifies `BuildConfig.DEBUG`. Injected rather than read directly because it is a compile-time
+ * constant: logic that reads it can only ever be exercised in one build type.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IsDebugBuild

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -1,114 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?><!--
+  AppNavigationScaffold owns the surrounding layout and the window insets that the former
+  ConstraintLayout root handled via fitsSystemWindows.
+-->
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/navHost"
+    android:name="androidx.navigation.fragment.NavHostFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    tools:context=".MainActivity">
-
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:elevation="4dp"
-        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <androidx.cardview.widget.CardView
-        android:id="@+id/batteryOptimizationWarning"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:visibility="gone"
-        app:cardBackgroundColor="?attr/colorTertiaryContainer"
-        app:cardCornerRadius="8dp"
-        app:cardUseCompatPadding="true"
-        app:layout_constraintTop_toBottomOf="@id/toolbar">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/battery_optimization_warning_title"
-                android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
-                android:textColor="?attr/colorOnTertiaryContainer" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/battery_optimization_warning_summary"
-                android:textColor="?attr/colorOnTertiaryContainer" />
-
-            <Button
-                android:id="@+id/dismissBatteryWarning"
-                style="@style/Widget.Material3.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="end"
-                android:text="@string/ok"
-                android:textColor="?attr/colorOnTertiaryContainer" />
-        </LinearLayout>
-    </androidx.cardview.widget.CardView>
-
-    <androidx.cardview.widget.CardView
-        android:id="@+id/exactRemindersWarning"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:visibility="gone"
-        app:cardBackgroundColor="?attr/colorTertiaryContainer"
-        app:cardCornerRadius="8dp"
-        app:cardUseCompatPadding="true"
-        app:layout_constraintTop_toBottomOf="@id/batteryOptimizationWarning">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/exact_reminders_warning_title"
-                android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
-                android:textColor="?attr/colorOnTertiaryContainer" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/exact_reminders_warning_summary"
-                android:textColor="?attr/colorOnTertiaryContainer" />
-
-            <Button
-                android:id="@+id/dismissExactReminderWarning"
-                style="@style/Widget.Material3.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="end"
-                android:text="@string/ok"
-                android:textColor="?attr/colorOnTertiaryContainer" />
-        </LinearLayout>
-    </androidx.cardview.widget.CardView>
-
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/navHost"
-        android:name="androidx.navigation.fragment.NavHostFragment"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:defaultNavHost="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/exactRemindersWarning"
-        app:navGraph="@navigation/navigation" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    app:defaultNavHost="true"
+    app:navGraph="@navigation/navigation"
+    tools:context=".MainActivity" />

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Inflated rather than constructed in the AndroidView factory so the ThemeOverlay below is applied
+  via the inflater's ContextThemeWrapper; constructing a Toolbar in code silently drops it.
+-->
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:elevation="4dp"
+    android:theme="@style/ThemeOverlay.AppCompat.ActionBar" />

--- a/app/src/test/java/com/futsch1/medtimer/MainScreenStateTest.kt
+++ b/app/src/test/java/com/futsch1/medtimer/MainScreenStateTest.kt
@@ -1,0 +1,96 @@
+package com.futsch1.medtimer
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainScreenStateTest {
+
+    @Test
+    fun `battery warning shows when not exempt, not dismissed and not suppressed`() {
+        assertTrue(
+            showBatteryOptimizationWarning(
+                warningsSuppressed = false,
+                isIgnoringBatteryOptimizations = false,
+                batteryWarningShown = false,
+            )
+        )
+    }
+
+    @Test
+    fun `battery warning is hidden once the exemption is granted`() {
+        assertFalse(
+            showBatteryOptimizationWarning(
+                warningsSuppressed = false,
+                isIgnoringBatteryOptimizations = true,
+                batteryWarningShown = false,
+            )
+        )
+    }
+
+    @Test
+    fun `battery warning is hidden once dismissed`() {
+        assertFalse(
+            showBatteryOptimizationWarning(
+                warningsSuppressed = false,
+                isIgnoringBatteryOptimizations = false,
+                batteryWarningShown = true,
+            )
+        )
+    }
+
+    @Test
+    fun `battery warning is hidden when suppressed`() {
+        assertFalse(
+            showBatteryOptimizationWarning(
+                warningsSuppressed = true,
+                isIgnoringBatteryOptimizations = false,
+                batteryWarningShown = false,
+            )
+        )
+    }
+
+    @Test
+    fun `exact reminders warning shows when disabled, not dismissed and not suppressed`() {
+        assertTrue(
+            showExactRemindersWarning(
+                warningsSuppressed = false,
+                exactReminders = false,
+                exactRemindersWarningShown = false,
+            )
+        )
+    }
+
+    @Test
+    fun `exact reminders warning is hidden once exact reminders are enabled`() {
+        assertFalse(
+            showExactRemindersWarning(
+                warningsSuppressed = false,
+                exactReminders = true,
+                exactRemindersWarningShown = false,
+            )
+        )
+    }
+
+    @Test
+    fun `exact reminders warning is hidden once dismissed`() {
+        assertFalse(
+            showExactRemindersWarning(
+                warningsSuppressed = false,
+                exactReminders = false,
+                exactRemindersWarningShown = true,
+            )
+        )
+    }
+
+    @Test
+    fun `exact reminders warning is hidden when suppressed`() {
+        assertFalse(
+            showExactRemindersWarning(
+                warningsSuppressed = true,
+                exactReminders = false,
+                exactRemindersWarningShown = false,
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/futsch1/medtimer/NavSuiteTypeTest.kt
+++ b/app/src/test/java/com/futsch1/medtimer/NavSuiteTypeTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.window.core.layout.WindowSizeClass.Companion.BREAKPOINTS_V1
 import androidx.window.core.layout.computeWindowSizeClass
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NavSuiteTypeTest {
@@ -37,5 +39,15 @@ class NavSuiteTypeTest {
     @Test
     fun `600dp width crosses into medium`() {
         assertEquals(NavigationSuiteType.NavigationRail, navSuiteType(infoFor(600f, 900f)))
+    }
+
+    @Test
+    fun `the navigation bar consumes the bottom inset for the content`() {
+        assertFalse(consumesBottomInset(NavigationSuiteType.NavigationBar))
+    }
+
+    @Test
+    fun `the navigation rail leaves the bottom inset to the content`() {
+        assertTrue(consumesBottomInset(NavigationSuiteType.NavigationRail))
     }
 }


### PR DESCRIPTION
@Futsch1 this PR migrates the main screen warning cards to Compose to reduce layers of View-Compose-View-etc nesting.