### PR TITLE
Introduce data seeding in instrumented tests

### DIFF
--- a/app/src/androidTest/java/com/futsch1/medtimer/BasicUITest.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/BasicUITest.kt
@@ -53,8 +53,9 @@ class BasicUITest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun menuHandlingTest() {
-        medicines.create("Test")
-        medicineEditor.addReminder("1", laterToday())
+        seed.medicine("Test") { reminder("1", laterToday()) }
+
+        medicines.clickItem(0)
 
         val cycleStart = Calendar.getInstance()
         cycleStart.set(2025, 1, 1)
@@ -103,7 +104,9 @@ class BasicUITest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun notesTest() {
-        medicines.create("Test")
+        seed.medicine("Test")
+
+        medicines.clickItem(0)
 
         val notesText = "Contains catnip\n\nmeow :3"
 
@@ -129,8 +132,7 @@ class BasicUITest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun overviewFilters() {
-        medicines.create("Test")
-        medicineEditor.addIntervalReminder("2", 24.hours)
+        val medicineId = seed.medicine("Test") { intervalReminder("2", 24.hours) }
 
         navigation.toOverview()
         overview.assertEventContains(TEST_2)
@@ -168,9 +170,7 @@ class BasicUITest : MedTimerTestBase() {
         overview.assertEventCount(0)
         overview.toggleFilter(OverviewFilter.SCHEDULED)
 
-        navigation.toMedicines()
-        medicines.clickItem(0)
-        medicineEditor.addReminder("1", laterToday())
+        seed.remindersOf(medicineId) { reminder("1", laterToday()) }
 
         navigation.toOverview()
 

--- a/app/src/androidTest/java/com/futsch1/medtimer/ManualDoseTest.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/ManualDoseTest.kt
@@ -59,12 +59,8 @@ class ManualDoseTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun testManualDoseOfDisabledReminder() {
-        // Create medication + reminder
-        medicines.create("Test")
-        medicineEditor.addReminder("1 pill", null)
-
-        // Disable reminder
-        reminders.inSettingsOf(0) { toggleEnabled() }
+        // Create medication with a disabled reminder
+        seed.medicine("Test") { reminder("1 pill", active = false) }
 
         // Create manual dose of the disabled reminder
         navigation.toOverview()

--- a/app/src/androidTest/java/com/futsch1/medtimer/MedTimerTestBase.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/MedTimerTestBase.kt
@@ -5,10 +5,13 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.futsch1.medtimer.core.common.di.TimeAccessModule
 import com.futsch1.medtimer.core.common.helpers.MedicineHelper
 import com.futsch1.medtimer.core.common.time.TimeAccess
+import com.futsch1.medtimer.core.domain.repository.MedicineRepository
+import com.futsch1.medtimer.core.domain.repository.ReminderRepository
 import com.futsch1.medtimer.core.ui.TimeFormatter
 import com.futsch1.medtimer.di.TimeFormatterEntryPoint
 import com.futsch1.medtimer.harness.FakeTimeAccess
 import com.futsch1.medtimer.harness.MedTimerTestHarness
+import com.futsch1.medtimer.harness.Seed
 import com.futsch1.medtimer.robots.Robots
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.testing.BindValue
@@ -22,6 +25,7 @@ import org.junit.runners.model.Statement
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.temporal.ChronoUnit
+import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -40,6 +44,12 @@ abstract class MedTimerTestBase {
     @BindValue
     val timeAccess: TimeAccess = FakeTimeAccess()
 
+    @Inject
+    lateinit var medicineRepository: MedicineRepository
+
+    @Inject
+    lateinit var reminderRepository: ReminderRepository
+
     private val harness = MedTimerTestHarness(this.javaClass.name)
 
     @get:Rule
@@ -55,6 +65,9 @@ abstract class MedTimerTestBase {
         .around(harness)
 
     protected val baristaRule get() = harness.baristaRule
+
+    /** A test's starting data, written past the editor - see [Seed]. */
+    protected val seed by lazy { Seed(medicineRepository, reminderRepository, timeAccess) }
 
     private val robots by lazy { Robots(harness.composeTestRule) }
 

--- a/app/src/androidTest/java/com/futsch1/medtimer/MedicineHandlingTest.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/MedicineHandlingTest.kt
@@ -54,10 +54,10 @@ class MedicineHandlingTest : MedTimerTestBase() {
             dialogs.clickItem(R.string.snooze)
         }
 
-        navigation.toMedicines()
-        medicines.create(TEST_MED_1)
-        medicineSettings.inSettings { toggleCannotBeSkipped() }
-        medicineEditor.addIntervalReminder("1", 2.hours)
+        seed.medicine(TEST_MED_1) {
+            cannotBeSkipped()
+            intervalReminder("1", 2.hours)
+        }
 
         notifications.inShade {
             assertShows(TEST_MED_1)
@@ -84,9 +84,7 @@ class MedicineHandlingTest : MedTimerTestBase() {
             preferences.click(R.string.reminders_cannot_be_skipped)
         }
 
-        navigation.toMedicines()
-        medicines.create(TEST_MED_1)
-        medicineEditor.addIntervalReminder("1", 2.hours)
+        seed.medicine(TEST_MED_1) { intervalReminder("1", 2.hours) }
 
         notifications.inShade {
             assertShows(TEST_MED_1)

--- a/app/src/androidTest/java/com/futsch1/medtimer/MedicineStockTest.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/MedicineStockTest.kt
@@ -19,17 +19,14 @@ class MedicineStockTest : MedTimerTestBase() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val notificationTitle = context.getString(R.string.out_of_stock_notification_title)
 
-        medicines.create("Test")
-
-        medicineEditor.setStock(amount = "", refillSize = "")
-        medicineEditor.setStock(amount = amount(10.5), unit = "pills", refillSize = amount(10.8))
-
-        // Interval reminder (amount 3.5) 10 minutes from now
-        medicineEditor.addIntervalReminder(
-            "Of the pills ${amount(3.5)} are to be taken",
-            intervalWithinToday(10.minutes)
-        )
-        medicineEditor.addStockReminder(threshold = "4")
+        seed.medicine("Test") {
+            stock(amount = 10.5, unit = "pills", refillSize = 10.8)
+            intervalReminder(
+                "Of the pills ${amount(3.5)} are to be taken",
+                intervalWithinToday(10.minutes)
+            )
+            stockReminder(threshold = 4.0)
+        }
 
         navigation.toOverview()
 
@@ -88,12 +85,11 @@ class MedicineStockTest : MedTimerTestBase() {
 
         settings.click(R.string.privacy_settings, R.string.hide_med_name)
 
-        medicines.create("TestMed")
-
-        medicineEditor.setStock(amount = "120", unit = "pills", refillSize = "100")
-
-        medicineEditor.addIntervalReminder("So many pills - 130", 10.minutes)
-        medicineEditor.addStockReminder(threshold = "0")
+        seed.medicine("TestMed") {
+            stock(amount = 120.0, unit = "pills", refillSize = 100.0)
+            intervalReminder("So many pills - 130", 10.minutes)
+            stockReminder(threshold = 0.0)
+        }
 
         navigation.toOverview()
         overview.clickEventState(0)
@@ -115,7 +111,9 @@ class MedicineStockTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun reminderAmountWarningTest() {
-        medicines.create("Test")
+        seed.medicine("Test")
+
+        medicines.clickItem(0)
 
         medicineEditor.setStock(amount = amount(10.5), unit = "pills")
         medicineEditor.addStockReminder(threshold = "4")
@@ -126,8 +124,11 @@ class MedicineStockTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun bigStockAmounts() {
-        medicines.create("Test")
+        seed.medicine("Test")
 
+        medicines.clickItem(0)
+
+        medicineEditor.setStock(amount = "", refillSize = "")
         medicineEditor.setStock(amount = "10005", unit = "pills")
 
         medicineEditor.inStockSettings {
@@ -142,8 +143,11 @@ class MedicineStockTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun runOutDate() {
-        medicines.create("Test")
-        medicineEditor.addReminder("3", earlierToday())
+        seed.medicine("Test") {
+            reminder("3", earlierToday())
+        }
+
+        medicines.clickItem(0)
 
         medicineEditor.inStockSettings {
             preferences.setValue(R.string.amount, "10")
@@ -165,12 +169,12 @@ class MedicineStockTest : MedTimerTestBase() {
     fun allTaken() {
         settings.click(R.string.display_settings, R.string.combine_notifications)
 
-        medicines.create(TEST_MED)
-        medicineEditor.addReminder("3", laterToday())
-        medicineEditor.addReminder("2", laterToday())
-        medicineEditor.addDailyStockReminder(threshold = "12", time = laterToday())
-
-        medicineEditor.setStock(amount = "10")
+        seed.medicine(TEST_MED) {
+            stock(amount = 10.0)
+            reminder("3", laterToday())
+            reminder("2", laterToday())
+            dailyStockReminder(threshold = 12.0, at = laterToday())
+        }
 
         scheduleRemindersNow()
         notifications.inShade {
@@ -178,6 +182,7 @@ class MedicineStockTest : MedTimerTestBase() {
             clickAction(R.string.taken)
         }
 
+        medicines.clickItem(0)
         medicineEditor.assertStockAmount("5")
     }
 
@@ -191,7 +196,9 @@ class MedicineStockTest : MedTimerTestBase() {
         val day = expirationTime.get(Calendar.DAY_OF_MONTH)
         expirationTime.set(Calendar.DAY_OF_MONTH, day + 7)
 
-        medicines.create("Test")
+        seed.medicine("Test")
+
+        medicines.clickItem(0)
         medicineEditor.inStockSettings {
             preferences.click(R.string.expiration_date)
             pickers.pickDate(expirationTime.time)
@@ -235,10 +242,10 @@ class MedicineStockTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun undoStockOnDeleteTest() {
-        medicines.create("Test")
-        medicineEditor.addReminder("2", laterToday())
-
-        medicineEditor.setStock(amount = "10", unit = "pills")
+        seed.medicine("Test") {
+            stock(amount = 10.0, unit = "pills")
+            reminder("2", laterToday())
+        }
 
         navigation.toOverview()
 
@@ -262,10 +269,10 @@ class MedicineStockTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun undoStockOnReraiseTest() {
-        medicines.create("Test")
-        medicineEditor.addReminder("2", laterToday())
-
-        medicineEditor.setStock(amount = "10", unit = "pills")
+        seed.medicine("Test") {
+            stock(amount = 10.0, unit = "pills")
+            reminder("2", laterToday())
+        }
 
         navigation.toOverview()
 
@@ -292,7 +299,9 @@ class MedicineStockTest : MedTimerTestBase() {
         val notificationTitle =
             InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.out_of_stock_notification_title)
 
-        medicines.create("Test")
+        seed.medicine("Test")
+
+        medicines.clickItem(0)
 
         medicineEditor.setStock(amount = amount(10.5))
         medicineEditor.addDailyStockReminder(threshold = "14", time = laterToday())

--- a/app/src/androidTest/java/com/futsch1/medtimer/NotificationTest.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/NotificationTest.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import com.adevinta.android.barista.rule.flaky.AllowFlaky
 import com.futsch1.medtimer.core.ui.R
 import com.futsch1.medtimer.utilities.awaitNextSecond
+import com.futsch1.medtimer.utilities.fireNextAlarmsAfter
 import com.futsch1.medtimer.utilities.scheduleRemindersNow
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
@@ -19,6 +20,7 @@ private const val FIRST_REMINDER = "First reminder"
 private const val SECOND_REMINDER = "Second reminder"
 private const val TEST_VARIABLE_AMOUNT = "Test variable amount"
 private const val TEST_ANOTHER_VARIABLE_AMOUNT = "Test another variable amount"
+private const val REPEAT_AFTER_MILLIS = 5_000L
 
 
 @HiltAndroidTest
@@ -26,13 +28,13 @@ class NotificationTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun notificationTest() {
-        medicines.create(TEST_MED)
+        seed.medicine(TEST_MED) {
+            reminder("1", aboutToFire())
+            linkedReminder("1", after = 1.minutes)
+        }
 
+        medicines.clickItem(0)
         medicineSettings.setColorAndIcon(hex = "deadbe", iconPosition = 1)
-
-        medicineEditor.addReminder("1", aboutToFire())
-
-        reminders.addLinkedReminder(0, minutes = 1)
 
         navigation.toOverview()
 
@@ -53,11 +55,8 @@ class NotificationTest : MedTimerTestBase() {
             dialogs.clickItem(R.string.skip_reminder)
         }
 
-        navigation.toMedicines()
-
-        medicines.create(TEST_MED)
         // Interval reminder (amount 1) 2 hours from now
-        medicineEditor.addIntervalReminder("1", 2.hours)
+        seed.medicine(TEST_MED) { intervalReminder("1", 2.hours) }
 
         navigation.toAnalysis()
         awaitAndDismissNotification()
@@ -101,9 +100,10 @@ class NotificationTest : MedTimerTestBase() {
 
         settings.click(R.string.display_settings, R.string.combine_notifications)
 
-        medicines.create(TEST_MED)
-        medicineEditor.addReminder(FIRST_REMINDER, laterToday())
-        medicineEditor.addReminder(SECOND_REMINDER, laterToday())
+        seed.medicine(TEST_MED) {
+            reminder(FIRST_REMINDER, laterToday())
+            reminder(SECOND_REMINDER, laterToday())
+        }
 
         scheduleRemindersNow()
 
@@ -114,6 +114,7 @@ class NotificationTest : MedTimerTestBase() {
         }
         navigation.toOverview()
 
+        fireNextAlarmsAfter(REPEAT_AFTER_MILLIS)
         overview.clickEventState(0)
         overview.clickAction(R.string.taken)
         navigation.toAnalysis()
@@ -122,7 +123,7 @@ class NotificationTest : MedTimerTestBase() {
             assertHidden(FIRST_REMINDER)
             val text = assertShows(SECOND_REMINDER).text
 
-            awaitGone(text, timeoutMillis = 120_000)
+            awaitGone(text, timeoutMillis = REPEAT_AFTER_MILLIS * 6)
             assertShows(TEST_MED)
             assertHidden(FIRST_REMINDER)
             assertShows(SECOND_REMINDER)
@@ -134,8 +135,9 @@ class NotificationTest : MedTimerTestBase() {
     fun variableAmount() {
         settings.click(R.string.display_settings, R.string.combine_notifications)
 
-        medicines.create(TEST_MED)
-        medicineEditor.addReminder("1", laterToday())
+        seed.medicine(TEST_MED) { reminder("1", laterToday()) }
+
+        medicines.clickItem(0)
         reminders.inSettingsOf(0) { toggleVariableAmount() }
         menus.clickEditMedicineOption(R.string.duplicate_including_reminders)
 
@@ -166,12 +168,11 @@ class NotificationTest : MedTimerTestBase() {
             preferences.click(R.string.combine_notifications)
         }
 
-        medicines.create(TEST_MED)
-        medicineEditor.addReminder("1", laterToday())
-        reminders.inSettingsOf(0) { toggleVariableAmount() }
-        menus.clickEditMedicineOption(R.string.duplicate_including_reminders)
+        val medicineId = seed.medicine(TEST_MED) { reminder("1", laterToday(), variableAmount = true) }
+
         medicines.clickItem(0)
-        medicineEditor.addReminder("Not variable", laterToday())
+        menus.clickEditMedicineOption(R.string.duplicate_including_reminders)
+        seed.remindersOf(medicineId) { reminder("Not variable", laterToday()) }
 
         medicines.clickItem(1)
         medicineEditor.rename(SECOND_ONE)
@@ -212,8 +213,7 @@ class NotificationTest : MedTimerTestBase() {
             dialogs.clickItem(R.string.snooze)
         }
 
-        medicines.create(TEST_MED)
-        medicineEditor.addIntervalReminder("1", 2.hours)
+        seed.medicine(TEST_MED) { intervalReminder("1", 2.hours) }
 
         navigation.toAnalysis()
         notifications.inShade {
@@ -256,8 +256,7 @@ class NotificationTest : MedTimerTestBase() {
     fun hiddenMedicineName() {
         settings.click(R.string.privacy_settings, R.string.hide_med_name)
 
-        medicines.create(TEST_MED)
-        medicineEditor.addIntervalReminder("1", 2.hours)
+        seed.medicine(TEST_MED) { intervalReminder("1", 2.hours) }
         medicines.assertNameContains(TEST_MED)
 
         notifications.inShade { assertShows("T*******") }
@@ -268,8 +267,7 @@ class NotificationTest : MedTimerTestBase() {
     fun bigButtons() {
         settings.click(R.string.display_settings, R.string.big_notifications)
 
-        medicines.create(TEST_MED)
-        medicineEditor.addIntervalReminder("1", 2.hours)
+        seed.medicine(TEST_MED) { intervalReminder("1", 2.hours) }
 
         notifications.inShade {
             assertShows(TEST_MED)
@@ -285,11 +283,12 @@ class NotificationTest : MedTimerTestBase() {
     fun sameTimeReminders() {
         settings.click(R.string.display_settings, R.string.combine_notifications)
 
-        medicines.create(TEST_MED)
         val notificationTime = aboutToFire()
 
-        medicineEditor.addReminder("1", notificationTime)
-        medicineEditor.addReminder(SECOND_ONE, notificationTime)
+        seed.medicine(TEST_MED) {
+            reminder("1", notificationTime)
+            reminder(SECOND_ONE, notificationTime)
+        }
 
         notifications.inShade {
             scheduleRemindersNow()
@@ -312,9 +311,9 @@ class NotificationTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun automaticallyTakenTest() {
-        medicines.create(TEST_MED)
+        seed.medicine(TEST_MED) { reminder("1", aboutToFire()) }
 
-        medicineEditor.addReminder("1", aboutToFire())
+        medicines.clickItem(0)
         reminders.inSettingsOf(0) { toggleAutomaticallyTaken() }
 
         navigation.toOverview()
@@ -332,8 +331,9 @@ class NotificationTest : MedTimerTestBase() {
         val timeToNotify = 10_000L
         alarm.wakeDevice()
 
-        medicines.create(TEST_MED)
-        medicineEditor.addIntervalReminder("1", 2.minutes)
+        seed.medicine(TEST_MED) { intervalReminder("1", 2.minutes) }
+
+        medicines.clickItem(0)
         medicineSettings.inSettings { setNotificationImportance(R.string.high_and_alarm) }
 
         navigation.toOverview()
@@ -362,9 +362,7 @@ class NotificationTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun scheduleReminderTest() {
-        medicines.create(TEST_MED)
-
-        medicineEditor.addReminder("1", laterToday())
+        seed.medicine(TEST_MED) { reminder("1", laterToday()) }
 
         navigation.toOverview()
 
@@ -379,9 +377,10 @@ class NotificationTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun noSkippedButton() {
-        medicines.create(TEST_MED)
-        medicineSettings.inSettings { toggleCannotBeSkipped() }
-        medicineEditor.addIntervalReminder("1", 2.hours)
+        seed.medicine(TEST_MED) {
+            cannotBeSkipped()
+            intervalReminder("1", 2.hours)
+        }
 
         notifications.inShade {
             assertShows(TEST_MED)
@@ -396,11 +395,10 @@ class NotificationTest : MedTimerTestBase() {
 
         settings.click(R.string.display_settings, R.string.big_notifications)
 
-        navigation.toMedicines()
-
-        medicines.create(TEST_MED_2)
-        medicineSettings.inSettings { toggleCannotBeSkipped() }
-        medicineEditor.addIntervalReminder("1", 2.hours)
+        seed.medicine(TEST_MED_2) {
+            cannotBeSkipped()
+            intervalReminder("1", 2.hours)
+        }
 
         notifications.inShade {
             assertShows(TEST_MED_2)

--- a/app/src/androidTest/java/com/futsch1/medtimer/NotificationTest.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/NotificationTest.kt
@@ -22,6 +22,9 @@ private const val TEST_VARIABLE_AMOUNT = "Test variable amount"
 private const val TEST_ANOTHER_VARIABLE_AMOUNT = "Test another variable amount"
 private const val REPEAT_AFTER_MILLIS = 5_000L
 
+/** Covers the repeat whether the armed alarm pulled it forward or it stayed at the configured minute. */
+private const val REPEAT_TIMEOUT_MILLIS = 90_000L
+
 
 @HiltAndroidTest
 class NotificationTest : MedTimerTestBase() {
@@ -84,6 +87,7 @@ class NotificationTest : MedTimerTestBase() {
     }
 
     @Test
+    @AllowFlaky(attempts = 3)
     fun repeatingReminders() {
         // Repeat reminder every minute and enable exact reminders
         settings.inSection(R.string.notification_reminder_settings) {
@@ -114,16 +118,17 @@ class NotificationTest : MedTimerTestBase() {
         }
         navigation.toOverview()
 
+        // Read before the repeat is armed, after which it can land at any moment.
+        val firstRaise = notifications.postedId(SECOND_REMINDER)
+
         fireNextAlarmsAfter(REPEAT_AFTER_MILLIS)
         overview.clickEventState(0)
         overview.clickAction(R.string.taken)
         navigation.toAnalysis()
 
-        notifications.inShade {
-            assertHidden(FIRST_REMINDER)
-            val text = assertShows(SECOND_REMINDER).text
+        notifications.awaitRaisedAgain(SECOND_REMINDER, firstRaise, timeoutMillis = REPEAT_TIMEOUT_MILLIS)
 
-            awaitGone(text, timeoutMillis = REPEAT_AFTER_MILLIS * 6)
+        notifications.inShade {
             assertShows(TEST_MED)
             assertHidden(FIRST_REMINDER)
             assertShows(SECOND_REMINDER)

--- a/app/src/androidTest/java/com/futsch1/medtimer/ReminderTest.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/ReminderTest.kt
@@ -27,9 +27,9 @@ class ReminderTest : MedTimerTestBase() {
         val pastTime = Calendar.getInstance()
         pastTime.set(year - 1, 1, 1)
 
-        medicines.create("Test")
-        medicineEditor.addReminder("1", laterToday())
+        seed.medicine("Test") { reminder("1", laterToday()) }
 
+        medicines.clickItem(0)
         reminders.inSettingsOf(0) { toggleEnabled() }
 
         navigation.toOverview()
@@ -89,9 +89,9 @@ class ReminderTest : MedTimerTestBase() {
         futureTime.set(year + 1, 1, 1)
         val nowTime = Calendar.getInstance()
 
-        medicines.create("Test")
-        medicineEditor.addIntervalReminder("1", 180.minutes)
+        seed.medicine("Test") { intervalReminder("1", 180.minutes) }
 
+        medicines.clickItem(0)
         reminders.inSettingsOf(0) {
             setIntervalStart(
                 futureTime.time,
@@ -186,7 +186,7 @@ class ReminderTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun editReminderTest() {
-        medicines.create("Test")
+        seed.medicine("Test")
 
         navigation.toOverview()
 
@@ -227,8 +227,7 @@ class ReminderTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun deleteReminderTest() {
-        medicines.create("Test")
-        medicineEditor.addReminder("1", laterToday())
+        seed.medicine("Test") { reminder("1", laterToday()) }
 
         navigation.toOverview()
 
@@ -247,8 +246,7 @@ class ReminderTest : MedTimerTestBase() {
     fun intervalReminderTest() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
 
-        medicines.create("Test")
-        medicineEditor.addIntervalReminder("1", intervalWithinToday(10.minutes))
+        seed.medicine("Test") { intervalReminder("1", intervalWithinToday(10.minutes)) }
 
         navigation.toOverview()
 
@@ -275,14 +273,15 @@ class ReminderTest : MedTimerTestBase() {
         )
 
         // Create medicine
-        medicines.create("Test")
+        val medicineId = seed.medicine("Test")
 
         for (cycle in reminderCycles) {
             // Create reminder
-            medicineEditor.addReminder("1", laterToday())
+            seed.remindersOf(medicineId) { reminder("1", laterToday()) }
 
             val cycleStart = Calendar.getInstance()
 
+            medicines.clickItem(0)
             reminders.inSettingsOf(0) {
                 inCycle {
                     setConsecutiveDays(cycle.consecutiveDays)
@@ -336,8 +335,7 @@ class ReminderTest : MedTimerTestBase() {
             pickers.pickTime(windowEnd)
         }
 
-        medicines.create(TEST_MED)
-        medicineEditor.addReminder("1", reminderTime)
+        seed.medicine(TEST_MED) { reminder("1", reminderTime) }
 
         navigation.toOverview()
         overview.assertEventContains(timeFormatter().minutesToTimeString(windowEnd.hour * 60 + windowEnd.minute))
@@ -348,8 +346,7 @@ class ReminderTest : MedTimerTestBase() {
     fun reschedule() {
         settings.click(R.string.display_settings, R.string.combine_notifications)
 
-        medicines.create(TEST_MED)
-        medicineEditor.addIntervalReminder("1", intervalWithinToday())
+        seed.medicine(TEST_MED) { intervalReminder("1", intervalWithinToday()) }
 
         navigation.toOverview()
         overview.assertEventCountAtLeast(2)

--- a/app/src/androidTest/java/com/futsch1/medtimer/TagTest.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/TagTest.kt
@@ -15,7 +15,8 @@ class TagTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun tagHandling() {
-        medicines.create("Test")
+        seed.medicine("Test")
+        medicines.clickItem(0)
 
         tags.inMedicineTags {
             add(NEW_TAG)
@@ -38,7 +39,8 @@ class TagTest : MedTimerTestBase() {
         medicines.assertListContains(NEW_TAG)
         medicines.assertListDoesNotContain(ANOTHER_TAG)
 
-        medicines.create("Test 2")
+        seed.medicine("Test 2")
+        medicines.clickItem(1)
 
         tags.inMedicineTags {
             assertNotChecked(NEW_TAG)
@@ -59,10 +61,12 @@ class TagTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun medicineVisibility() {
-        medicines.create("Test")
+        seed.medicine("Test")
+        medicines.clickItem(0)
         tags.inMedicineTags { add("Tag1") }
 
-        medicines.create("Else")
+        seed.medicine("Else")
+        medicines.clickItem(1)
         tags.inMedicineTags { add("Tag2") }
 
         medicines.assertNameContains("Test")
@@ -91,13 +95,13 @@ class TagTest : MedTimerTestBase() {
     @Test
     @AllowFlaky(attempts = 3)
     fun activateAndOverviewVisibility() {
-        medicines.create("Test")
+        seed.medicine("Test") { intervalReminder("Amount1", 1.hours) }
+        medicines.clickItem(0)
         tags.inMedicineTags { add("Tag1") }
-        medicineEditor.addIntervalReminder("Amount1", 1.hours)
 
-        medicines.create("Else")
+        seed.medicine("Else") { intervalReminder("Amount2", 1.hours) }
+        medicines.clickItem(1)
         tags.inMedicineTags { add("Tag2") }
-        medicineEditor.addIntervalReminder("Amount2", 1.hours)
 
         // First, deactivate all of Test
         medicines.showList()

--- a/app/src/androidTest/java/com/futsch1/medtimer/harness/Seed.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/harness/Seed.kt
@@ -44,17 +44,24 @@ class Seed(
         create(MedicineSeed(timeAccess).apply(block).reminders, medicineId)
     }
 
+    /** One write: the app reschedules off each, so a medicine added a reminder at a time is catchable half-built. */
     private suspend fun create(reminders: List<Pair<Reminder, Int?>>, medicineId: Int) {
-        val reminderIds = mutableListOf<Int>()
-        for ((reminder, linkedToPosition) in reminders) {
-            reminderIds += reminderRepository.create(
+        val reminderIds = reminderRepository.createMany(
+            reminders.map { (reminder, _) -> reminder.copy(medicineRelId = medicineId) }
+        )
+
+        // A link holds the position of the reminder it follows, whose id only exists once written.
+        val linked = reminders.mapIndexedNotNull { position, (reminder, linkedToPosition) ->
+            linkedToPosition?.let {
                 reminder.copy(
+                    id = reminderIds[position],
                     medicineRelId = medicineId,
-                    // A linked reminder is built holding the position of the reminder it follows;
-                    // its id only exists once that one has been written.
-                    linkedReminderId = linkedToPosition?.let { reminderIds[it] } ?: 0
+                    linkedReminderId = reminderIds[it]
                 )
-            )
+            }
+        }
+        if (linked.isNotEmpty()) {
+            reminderRepository.updateMany(linked)
         }
     }
 

--- a/app/src/androidTest/java/com/futsch1/medtimer/harness/Seed.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/harness/Seed.kt
@@ -1,0 +1,147 @@
+package com.futsch1.medtimer.harness
+
+import com.futsch1.medtimer.core.common.time.TimeAccess
+import com.futsch1.medtimer.core.domain.model.Medicine
+import com.futsch1.medtimer.core.domain.model.Reminder
+import com.futsch1.medtimer.core.domain.model.ReminderTime
+import com.futsch1.medtimer.core.domain.repository.MedicineRepository
+import com.futsch1.medtimer.core.domain.repository.ReminderRepository
+import kotlinx.coroutines.runBlocking
+import java.time.LocalTime
+import kotlin.time.Duration
+
+/**
+ * A test's starting data, written straight into the repositories.
+ *
+ * Arranging a medicine and its reminders through the editor costs roughly fifteen seconds per test
+ * on CI's emulator, and the editor is not what most tests are about. The tests that own a creation
+ * flow still drive it - see docs/guidelines/testing.md - everything else arranges here.
+ *
+ * What lands in the database is what the editor writes: the same defaults [Medicine] and [Reminder]
+ * start from, and the same fields the new-reminder dialogs fill in. The app reacts to the write the
+ * way it reacts to the editor's, so scheduling and the overview follow on their own.
+ */
+class Seed(
+    private val medicineRepository: MedicineRepository,
+    private val reminderRepository: ReminderRepository,
+    private val timeAccess: TimeAccess
+) {
+
+    /** Creates [name] with whatever [block] adds to it, and answers its id. */
+    fun medicine(name: String, block: MedicineSeed.() -> Unit = {}): Int = runBlocking {
+        val seed = MedicineSeed(timeAccess).apply(block)
+
+        val medicineId = medicineRepository.create(
+            seed.medicine.copy(name = name, sortOrder = medicineRepository.getHighestSortOrder())
+        )
+        create(seed.reminders, medicineId)
+
+        medicineId
+    }
+
+    /** Adds reminders to a medicine that is already there - for state a test builds up in steps. */
+    fun remindersOf(medicineId: Int, block: MedicineSeed.() -> Unit) = runBlocking {
+        create(MedicineSeed(timeAccess).apply(block).reminders, medicineId)
+    }
+
+    private suspend fun create(reminders: List<Pair<Reminder, Int?>>, medicineId: Int) {
+        val reminderIds = mutableListOf<Int>()
+        for ((reminder, linkedToPosition) in reminders) {
+            reminderIds += reminderRepository.create(
+                reminder.copy(
+                    medicineRelId = medicineId,
+                    // A linked reminder is built holding the position of the reminder it follows;
+                    // its id only exists once that one has been written.
+                    linkedReminderId = linkedToPosition?.let { reminderIds[it] } ?: 0
+                )
+            )
+        }
+    }
+
+    /** The medicine under construction: its stock, its appearance and the reminders on it. */
+    class MedicineSeed internal constructor(private val timeAccess: TimeAccess) {
+        internal var medicine: Medicine = Medicine.default()
+        internal val reminders = mutableListOf<Pair<Reminder, Int?>>()
+
+        fun stock(amount: Double, unit: String = "", refillSize: Double = 0.0) {
+            medicine = medicine.copy(amount = amount, unit = unit, refillSize = refillSize)
+        }
+
+        fun cannotBeSkipped() {
+            medicine = medicine.copy(cannotBeSkipped = true)
+        }
+
+        /** A time based reminder, the kind the time based card creates. */
+        fun reminder(
+            amount: String,
+            time: LocalTime = ReminderTime(ReminderTime.DEFAULT_TIME).getLocalTime(),
+            variableAmount: Boolean = false,
+            automaticallyTaken: Boolean = false,
+            active: Boolean = true
+        ) {
+            add(
+                newReminder().copy(
+                    amount = amount,
+                    time = ReminderTime(time),
+                    variableAmount = variableAmount,
+                    automaticallyTaken = automaticallyTaken,
+                    active = active
+                )
+            )
+        }
+
+        /** A continuous interval reminder, counting from now the way the dialog starts it. */
+        fun intervalReminder(amount: String, interval: Duration) {
+            add(
+                newReminder().copy(
+                    amount = amount,
+                    time = ReminderTime(interval.inWholeMinutes.toInt(), isDuration = true),
+                    intervalStart = timeAccess.now()
+                )
+            )
+        }
+
+        /** A reminder [after] the one added before it, the way the linked reminder dialog creates it. */
+        fun linkedReminder(amount: String, after: Duration) {
+            val linkedToPosition = reminders.size - 1
+            add(
+                newReminder().copy(
+                    amount = amount,
+                    time = ReminderTime(after.inWholeMinutes.toInt(), isDuration = true)
+                ),
+                linkedToPosition
+            )
+        }
+
+        /** Fires once when the stock falls to [threshold]. */
+        fun stockReminder(threshold: Double) {
+            add(
+                newReminder().copy(
+                    outOfStockThreshold = threshold,
+                    outOfStockReminderType = Reminder.OutOfStockReminderType.ONCE
+                )
+            )
+        }
+
+        /** Fires at [at] on every day the stock sits below [threshold]. */
+        fun dailyStockReminder(threshold: Double, at: LocalTime) {
+            add(
+                newReminder().copy(
+                    time = ReminderTime(at),
+                    outOfStockThreshold = threshold,
+                    outOfStockReminderType = Reminder.OutOfStockReminderType.DAILY
+                )
+            )
+        }
+
+        private fun add(reminder: Reminder, linkedToPosition: Int? = null) {
+            reminders += reminder to linkedToPosition
+        }
+
+        private fun newReminder() = Reminder.default().copy(
+            createdTime = timeAccess.now(),
+            cycleStartDay = timeAccess.localDate().plusDays(1),
+            instructions = ""
+        )
+    }
+}

--- a/app/src/androidTest/java/com/futsch1/medtimer/robots/MaterialPickers.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/robots/MaterialPickers.kt
@@ -20,6 +20,7 @@ import java.text.SimpleDateFormat
 import java.time.LocalTime
 import java.util.Date
 import java.util.Locale
+import kotlin.test.fail
 
 /**
  * The Material time and date picker dialogs. Locale (12- vs 24-hour, the date input pattern) and
@@ -35,6 +36,7 @@ class MaterialPickers {
     fun confirmTime() = confirmAndAwaitDismissal(com.google.android.material.R.id.material_timepicker_ok_button)
 
     fun pickDate(date: Date) {
+        awaitPicker(com.google.android.material.R.id.confirm_button)
         awaitView(ViewMatchers.withId(com.google.android.material.R.id.mtrl_picker_header_toggle))
         switchToTextInput(com.google.android.material.R.id.mtrl_picker_header_toggle, dateTextInput)
         writeTo(com.google.android.material.R.id.mtrl_picker_text_input_date, inputFormat.format(date))
@@ -42,13 +44,29 @@ class MaterialPickers {
         confirmAndAwaitDismissal(com.google.android.material.R.id.confirm_button)
     }
 
-    /** The picker goes down with a fragment transaction Espresso does not idle on, so the next tap can hit it. */
-    private fun confirmAndAwaitDismissal(buttonId: Int) {
-        clickOn(buttonId)
+    /** Until the picker's window is up, Espresso resolves the screen behind it as the root. */
+    private fun awaitPicker(confirmButtonId: Int) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
-        val resourceName = instrumentation.targetContext.resources.getResourceName(buttonId)
-        UiDevice.getInstance(instrumentation).wait(Until.gone(By.res(resourceName)), DISMISSAL_TIMEOUT)
+        UiDevice.getInstance(instrumentation)
+            .wait(Until.hasObject(selector(confirmButtonId)), DISMISSAL_TIMEOUT)
     }
+
+    /** A picker left standing swallows the next tap, so the dismissal is retried and then insisted on. */
+    private fun confirmAndAwaitDismissal(buttonId: Int) {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        val confirmButton = selector(buttonId)
+
+        repeat(CONFIRM_ATTEMPTS) { attempt ->
+            if (attempt == 0 || viewAppears(displayedView(buttonId))) {
+                clickOn(buttonId)
+            }
+            if (device.wait(Until.gone(confirmButton), DISMISSAL_TIMEOUT)) return
+        }
+        fail("The picker was still up after $CONFIRM_ATTEMPTS taps on its confirm button")
+    }
+
+    private fun selector(viewId: Int) =
+        By.res(InstrumentationRegistry.getInstrumentation().targetContext.resources.getResourceName(viewId))
 
     private fun switchToTextInput(toggleId: Int, field: Matcher<View>) {
         repeat(MODE_TOGGLE_ATTEMPTS) {
@@ -60,6 +78,8 @@ class MaterialPickers {
     }
 
     private fun enterTime(hour: Int, minute: Int, isDuration: Boolean) {
+        awaitPicker(com.google.android.material.R.id.material_timepicker_ok_button)
+
         var hour = hour
         if (!DateFormat.is24HourFormat(InstrumentationRegistry.getInstrumentation().targetContext) && !isDuration) {
             clickOn(com.google.android.material.R.id.material_clock_period_am_button)
@@ -122,5 +142,6 @@ class MaterialPickers {
         const val MODE_TOGGLE_ATTEMPTS = 3
         const val MODE_SETTLE_TIMEOUT = 2_000L
         const val DISMISSAL_TIMEOUT = 5_000L
+        const val CONFIRM_ATTEMPTS = 3
     }
 }

--- a/app/src/androidTest/java/com/futsch1/medtimer/robots/MedicineEditorRobot.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/robots/MedicineEditorRobot.kt
@@ -8,6 +8,7 @@ import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assert
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaEditTextInteractions.writeTo
 import com.adevinta.android.barista.interaction.BaristaKeyboardInteractions.closeKeyboard
+import com.adevinta.android.barista.interaction.BaristaScrollInteractions.safelyScrollTo
 import com.futsch1.medtimer.core.ui.R
 import java.time.LocalTime
 import kotlin.time.Duration
@@ -44,17 +45,6 @@ class MedicineEditorRobot(
         }
         closeKeyboard()
 
-        create()
-    }
-
-    fun addIntervalReminder(amount: String, interval: Duration) {
-        openCard(com.futsch1.medtimer.feature.ui.R.id.continuousIntervalCard)
-        writeTo(AMOUNT, amount)
-
-        clickOn(com.futsch1.medtimer.feature.ui.R.id.intervalMinutes)
-        writeTo(com.futsch1.medtimer.feature.ui.R.id.editIntervalTime, interval.inWholeMinutes.toString())
-
-        closeKeyboard()
         create()
     }
 
@@ -146,8 +136,10 @@ class MedicineEditorRobot(
         writeTo(com.futsch1.medtimer.feature.ui.R.id.editStockThreshold, threshold)
     }
 
+    /** On a short screen - a tablet in landscape - the card sits below the dialog's fold. */
     private fun openCard(cardId: Int) {
         clickOn(com.futsch1.medtimer.feature.ui.R.id.addReminder)
+        safelyScrollTo(cardId)
         clickOn(cardId)
     }
 
@@ -157,7 +149,11 @@ class MedicineEditorRobot(
         closeKeyboard()
     }
 
-    private fun create() = clickOn(com.futsch1.medtimer.feature.ui.R.id.createReminder)
+    /** The button sits below the dialog's fold on a short screen, same as the cards. */
+    private fun create() {
+        safelyScrollTo(com.futsch1.medtimer.feature.ui.R.id.createReminder)
+        clickOn(com.futsch1.medtimer.feature.ui.R.id.createReminder)
+    }
 
     private companion object {
         val AMOUNT = com.futsch1.medtimer.feature.ui.R.id.editAmount

--- a/app/src/androidTest/java/com/futsch1/medtimer/robots/NotificationShadeRobot.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/robots/NotificationShadeRobot.kt
@@ -1,6 +1,11 @@
 package com.futsch1.medtimer.robots
 
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
 import android.os.Build
+import android.os.SystemClock
+import android.service.notification.StatusBarNotification
 import androidx.annotation.StringRes
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
@@ -58,9 +63,51 @@ class NotificationShadeRobot {
             runCatching { it.text }.getOrNull()
         }.filter { it.isNotBlank() }
 
-    fun awaitGone(text: String, timeoutMillis: Long = DEFAULT_TIMEOUT) {
-        assertTrue(device.wait(Until.gone(By.text(text)), timeoutMillis), "Notification '$text' never disappeared")
+    /** The id [text] is posted under, for [awaitRaisedAgain]. Take it before anything can raise it again. */
+    fun postedId(text: String): Int =
+        assertNotNull(postedIdOrNull(text), "No posted notification contains '$text'. Posted: ${postedDescriptions()}")
+
+    /**
+     * Waits for [text], posted under [previousId], to be raised again - a repeat, a snooze coming back.
+     * Only the new id says so: the shade's timestamp resolves to minutes, and the post time also moves
+     * on a plain update.
+     */
+    fun awaitRaisedAgain(text: String, previousId: Int, timeoutMillis: Long = DEFAULT_TIMEOUT) {
+        val deadline = SystemClock.uptimeMillis() + timeoutMillis
+        var current = previousId
+        while (current == previousId && SystemClock.uptimeMillis() < deadline) {
+            SystemClock.sleep(POLL_INTERVAL)
+            // Raising it again cancels the old one first, so a momentary absence is not an answer.
+            current = postedIdOrNull(text) ?: current
+        }
+        assertTrue(
+            current != previousId,
+            "Notification containing '$text' was never raised again, still posted as id $previousId. " +
+                    "Posted: ${postedDescriptions()}"
+        )
     }
+
+    private fun postedIdOrNull(text: String): Int? =
+        activeNotifications().filter { it.notification.textsOf().any { line -> line.contains(text) } }
+            .maxByOrNull { it.postTime }?.id
+
+    private fun activeNotifications(): List<StatusBarNotification> {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        return notificationManager.activeNotifications.toList()
+    }
+
+    /** The posted notifications as the assertions see them, so a failure can explain itself. */
+    private fun postedDescriptions(): List<String> =
+        activeNotifications().map { "id=${it.id} postTime=${it.postTime} ${it.notification.textsOf()}" }
+
+    private fun Notification.textsOf(): List<String> = listOfNotNull(
+        extras.getCharSequence(Notification.EXTRA_TITLE),
+        extras.getCharSequence(Notification.EXTRA_TEXT),
+        extras.getCharSequence(Notification.EXTRA_BIG_TEXT),
+        extras.getCharSequence(Notification.EXTRA_SUB_TEXT),
+    ).map { it.toString() } + (extras.getCharSequenceArray(Notification.EXTRA_TEXT_LINES)?.map { it.toString() }
+        ?: emptyList())
 
     fun assertShowsAction(@StringRes textRes: Int, vararg args: Any) {
         val label = actionLabel(textRes, *args)
@@ -136,5 +183,6 @@ class NotificationShadeRobot {
 
     companion object {
         const val DEFAULT_TIMEOUT = 2_000L
+        private const val POLL_INTERVAL = 100L
     }
 }

--- a/app/src/androidTest/java/com/futsch1/medtimer/robots/PreferenceScreenRobot.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/robots/PreferenceScreenRobot.kt
@@ -13,6 +13,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import com.adevinta.android.barista.interaction.BaristaEditTextInteractions.writeTo
 import com.adevinta.android.barista.interaction.BaristaKeyboardInteractions.closeKeyboard
 import com.futsch1.medtimer.utilities.pollUntil
+import com.futsch1.medtimer.utilities.viewAppears
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
 
@@ -31,6 +32,17 @@ class PreferenceScreenRobot(private val ui: ComposeUi, private val dialogs: Dial
 
     /** Leaves a nested preference screen opened by [click]. */
     fun back() = pressBack()
+
+    /** Backs out of up to [screens] screens: a press with nothing to pop finishes the activity. */
+    fun leave(screens: Int) {
+        repeat(screens) {
+            if (!onPreferenceScreen()) return
+            pressBack()
+        }
+    }
+
+    private fun onPreferenceScreen(): Boolean =
+        viewAppears(Matchers.allOf(ViewMatchers.withId(androidx.preference.R.id.recycler_view), ViewMatchers.isDisplayed()))
 
     /** Opens the row's edit dialog and replaces its value. */
     fun setValue(@StringRes titleRes: Int, value: String) {

--- a/app/src/androidTest/java/com/futsch1/medtimer/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/robots/SettingsRobot.kt
@@ -1,7 +1,6 @@
 package com.futsch1.medtimer.robots
 
 import androidx.annotation.StringRes
-import androidx.test.espresso.Espresso.pressBack
 
 /**
  * The app settings. The interface is the setting to change; finding it and coming back out again is
@@ -17,7 +16,7 @@ class SettingsRobot(private val menus: MenuRobot, private val preferences: Prefe
         menus.clickAppOption(com.futsch1.medtimer.core.ui.R.string.tab_settings)
         path.forEach { preferences.click(it) }
         block()
-        repeat(path.size + 1) { pressBack() }
+        preferences.leave(path.size + 1)
     }
 
     /** Clicks the last entry of [path], with the entries before it read as nested screens. */

--- a/app/src/androidTest/java/com/futsch1/medtimer/utilities/InteractionsUtilities.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/utilities/InteractionsUtilities.kt
@@ -11,6 +11,15 @@ fun scheduleRemindersNow(delayMillis: Long = 0, repeats: Int = 0) {
     )
 }
 
+/**
+ * Pulls the next [repeats] + 1 alarms the app schedules by itself forward to [delayMillis] from now.
+ * The shortest repeat interval a user can pick is a minute, so a test that waits one out spends a
+ * minute doing nothing; call this right before the action that schedules the repeat instead.
+ */
+fun fireNextAlarmsAfter(delayMillis: Long, repeats: Int = 0) {
+    ReminderProcessorBroadcastReceiver.armNextAlarmsForTests(delayMillis, repeats)
+}
+
 /** Reminder events are keyed by their remind second, so one raised in the same second reuses the previous event. */
 fun awaitNextSecond() {
     SystemClock.sleep(1000 - System.currentTimeMillis() % 1000)

--- a/core/database/src/main/java/com/futsch1/medtimer/database/ReminderRepositoryImpl.kt
+++ b/core/database/src/main/java/com/futsch1/medtimer/database/ReminderRepositoryImpl.kt
@@ -37,8 +37,8 @@ class ReminderRepositoryImpl(
         return reminderDao.create(reminder.toEntity()).toInt()
     }
 
-    override suspend fun createMany(reminders: List<Reminder>) {
-        reminderDao.createAll(reminders.map { it.toEntity() })
+    override suspend fun createMany(reminders: List<Reminder>): List<Int> {
+        return reminderDao.createAll(reminders.map { it.toEntity() }).map { it.toInt() }
     }
 
     override suspend fun update(reminder: Reminder) {

--- a/core/database/src/main/java/com/futsch1/medtimer/database/dao/ReminderDao.kt
+++ b/core/database/src/main/java/com/futsch1/medtimer/database/dao/ReminderDao.kt
@@ -30,7 +30,7 @@ interface ReminderDao {
     suspend fun create(reminder: ReminderEntity): Long
 
     @Insert
-    suspend fun createAll(reminders: List<ReminderEntity>)
+    suspend fun createAll(reminders: List<ReminderEntity>): List<Long>
 
     @Update
     suspend fun update(reminder: ReminderEntity)

--- a/core/domain/src/main/java/com/futsch1/medtimer/core/domain/repository/ReminderRepository.kt
+++ b/core/domain/src/main/java/com/futsch1/medtimer/core/domain/repository/ReminderRepository.kt
@@ -10,7 +10,7 @@ interface ReminderRepository {
     fun getFlow(reminderId: Int): Flow<Reminder?>
     suspend fun getLinked(reminderId: Int): List<Reminder>
     suspend fun create(reminder: Reminder): Int
-    suspend fun createMany(reminders: List<Reminder>)
+    suspend fun createMany(reminders: List<Reminder>): List<Int>
     suspend fun update(reminder: Reminder)
     suspend fun updateMany(reminders: List<Reminder>)
     suspend fun delete(reminderId: Int)

--- a/docs/guidelines/testing.md
+++ b/docs/guidelines/testing.md
@@ -108,6 +108,11 @@ Conventions:
 - **UIAutomator** for cross-app interactions (notifications, settings screens) where Espresso can't reach.
 - Name tests for the user-visible behavior, not the Fragment class name.
 - Keep instrumented tests **independent** — each test sets up its own state via repository or intent, doesn't rely on test order.
+- **Arrange through `seed`, not through the UI.**
+  `MedTimerTestBase.seed` (see `harness/Seed.kt`) writes the fixture straight into the repositories, exactly as the UI would;
+  the app schedules and redraws off that write like any other.
+  Only a test that *owns* a creation flow clicks through it — everything else seeds.
+  Removing the last UI coverage of a flow is not a speed-up — move it to the test that owns it instead.
 - **Never make a test depend on what today is.** Derive times from now — `laterToday()`, `aboutToFire()`, `earlierToday()` on `MedTimerTestBase` — and
   dates from `LocalDate.now()`. A literal like `LocalTime.of(20, 0)` only means "in the future" on a device whose clock happens to cooperate, and the
   suite no longer pins one. `MedTimerTestHarness` fails any test started outside 03:00–21:00, which is what gives those helpers room to reach forwards and

--- a/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/ReminderProcessorBroadcastReceiver.kt
+++ b/feature/reminders/src/main/java/com/futsch1/medtimer/feature/reminders/ReminderProcessorBroadcastReceiver.kt
@@ -106,11 +106,21 @@ class ReminderProcessorBroadcastReceiver : BroadcastReceiver() {
          * Schedule broadcast so instrumented tests exercise the OS-reentry path end-to-end.
          */
         fun requestScheduleNowForTests(context: Context, delay: Long = 0, repeats: Int = 0) {
-            AlarmProcessor.delay = delay
-            AlarmProcessor.repeats = repeats
+            armNextAlarmsForTests(delay, repeats)
 
             val intent = getRequestScheduleIntent(context)
             context.sendBroadcast(intent, RECEIVER_PERMISSION)
+        }
+
+        /**
+         * Test-only seam: arms the same globals without asking for a schedule, so the next alarms
+         * the app sets on its own - a repeat, a snooze - land after [delay] instead of after the
+         * minutes the user configured. Lets a test wait seconds for a path whose real interval is
+         * minutes, with everything but the alarm timestamp still going through production code.
+         */
+        fun armNextAlarmsForTests(delay: Long, repeats: Int = 0) {
+            AlarmProcessor.delay = delay
+            AlarmProcessor.repeats = repeats
         }
     }
 }


### PR DESCRIPTION
This pull request replaces some of manual steps with database seeding in the instrumented tests.
This prevents repeating already tested paths and speeds up the tests.