### PR TITLE
#1418 Add regression tests for missed automatically taken reminders

### DIFF
--- a/app/src/androidTest/java/com/futsch1/medtimer/MissedAutomaticallyTakenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/futsch1/medtimer/MissedAutomaticallyTakenInstrumentedTest.kt
@@ -1,0 +1,45 @@
+package com.futsch1.medtimer
+
+import com.adevinta.android.barista.rule.flaky.AllowFlaky
+import com.futsch1.medtimer.core.ui.R
+import com.futsch1.medtimer.utilities.scheduleRemindersNow
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+
+/**
+ * Higher-level verification for https://github.com/Futsch1/medTimer/issues/1418
+ * ("Battery dead = missing medications").
+ *
+ * The #1418 scenario: the device is off (battery dead) when an automatically-taken
+ * reminder falls due. On the next app reschedule/start, the missed dose must be
+ * caught up and recorded as TAKEN - not left pending and not raised for a manual action.
+ *
+ * End-to-end on the device (frozen-clock harness): an automatically-taken reminder whose
+ * time is ALREADY BEHIND now ([MedTimerTestBase.earlierToday]) is processed via
+ * [scheduleRemindersNow]; the overview must show it as taken and no "taken" action may
+ * remain in the notification shade. This mirrors the maintainer's `automaticallyTakenTest`
+ * but with a PAST reminder time - the missed-while-off case - instead of a future one.
+ *
+ * Note: unlike the future-time case, a past-time reminder has NO pre-existing overview event
+ * (nothing was processed yet), so the "please wait" intermediate state is intentionally not
+ * asserted - only the post-catch-up "taken" state matters for the #1418 scenario.
+ */
+@HiltAndroidTest
+class MissedAutomaticallyTakenInstrumentedTest : MedTimerTestBase() {
+
+    @Test
+    @AllowFlaky(attempts = 3)
+    fun missedAutomaticallyTakenReminderIsRecordedAsTaken() {
+        medicines.create(TEST_MED)
+
+        medicineEditor.addReminder("1", earlierToday())
+        reminders.inSettingsOf(0) { toggleAutomaticallyTaken() }
+
+        navigation.toOverview()
+
+        scheduleRemindersNow()
+        overview.assertEventState(0, R.string.taken)
+
+        notifications.inShade { assertHidden(actionLabel(R.string.taken)) }
+    }
+}

--- a/app/src/test/java/com/futsch1/medtimer/processortests/MissedAutomaticallyTakenReminderTest.kt
+++ b/app/src/test/java/com/futsch1/medtimer/processortests/MissedAutomaticallyTakenReminderTest.kt
@@ -1,0 +1,271 @@
+package com.futsch1.medtimer.processortests
+
+import android.app.AlarmManager
+import android.app.NotificationManager
+import android.app.PendingIntent
+import com.futsch1.medtimer.core.common.di.TimeAccessModule
+import com.futsch1.medtimer.core.datastore.di.DatastoreModule
+import com.futsch1.medtimer.core.domain.model.ReminderEvent
+import com.futsch1.medtimer.database.MedicineEntity
+import com.futsch1.medtimer.database.dao.MedicineDao
+import com.futsch1.medtimer.database.dao.ReminderDao
+import com.futsch1.medtimer.database.dao.ReminderEventDao
+import com.futsch1.medtimer.database.dao.TagDao
+import com.futsch1.medtimer.database.di.DatabaseModule
+import com.futsch1.medtimer.database.toModel.toEntity
+import com.futsch1.medtimer.database.toModel.toModel
+import com.futsch1.medtimer.feature.reminders.ScheduleNextReminderNotificationProcessor
+import com.futsch1.medtimer.schedulertests.TestHelper
+import dagger.hilt.android.testing.BindValue
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+import javax.inject.Inject
+import kotlin.test.assertEquals
+
+/**
+ * Reproduction test for https://github.com/Futsch1/medTimer/issues/1418
+ * ("Battery dead = missing medications").
+ *
+ * ## The reported bug
+ *
+ * When the smartphone battery dies (or the device is powered off) at the moment a reminder is
+ * due, that reminder is not processed: the alarm fires while the device is off and the
+ * [ReminderNotificationProcessor] never runs, so no [ReminderEvent] is created in the database.
+ *
+ * After the device boots again, [com.futsch1.medtimer.Autostart] runs
+ * [com.futsch1.medtimer.AutostartService.restoreNotifications] (which only re-shows *existing*
+ * raised events — nothing exists for a missed reminder) and then asks the
+ * [ScheduleNextReminderNotificationProcessor] to schedule the next notification.
+ *
+ * The scheduler intentionally returns *today's already-past* reminder time for a reminder that
+ * was not raised yet (see `StandardScheduling.canScheduleEveryDay`: `possibleDays[0] =
+ * reminderBeforeCreation() && !raisedToday`). [AlarmProcessor.setNextReminderAlarm] detects the
+ * past instant and processes the reminder immediately instead of scheduling an alarm.
+ *
+ * For a reminder with `automaticallyTaken = true` the immediate processing must mark the missed
+ * medication as TAKEN (so the "missing medication" is added to the history, and the stock is
+ * decreased) — that is the expected behaviour from the issue. This test pins that behaviour.
+ *
+ * ## Scenario layout
+ *
+ * A reminder is set for 10:00 (600 minutes) on the fixed test day (epoch day 0, UTC). The
+ * "device was off" case is simulated by advancing the clock to 11:00 with *no* reminder event
+ * in the repository — exactly the state after a missed alarm and a reboot.
+ *
+ * 1. [missedAutomaticallyTakenReminderIsAddedAsTaken] — the reported bug: the missed
+ *    automatically-taken reminder must end up as a TAKEN event.
+ * 2. [missedNonAutomaticallyTakenReminderIsRaised] — control case: a normal reminder must end
+ *    up as a RAISED event (the notification is then shown to the user).
+ * 3. [deviceOnAtReminderTime] — contrast case: with the device on *before* the reminder time,
+ *    no event is created yet; only an alarm is scheduled.
+ *
+ * The tests run the same entry point the app uses after boot
+ * ([ScheduleNextReminderNotificationProcessor.scheduleNextReminder]) and inspect the in-memory
+ * fake repositories, so they fail/succeed purely on the presence and status of the created
+ * reminder events.
+ */
+@HiltAndroidTest
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+@UninstallModules(
+    DatabaseModule::class,
+    DatastoreModule::class,
+    TimeAccessModule::class
+)
+class MissedAutomaticallyTakenReminderTest {
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun init() {
+        hiltRule.inject()
+    }
+
+    private val reminderContext = TestReminderContext()
+
+    @BindValue
+    val boundAlarmManager: AlarmManager = reminderContext.alarmManagerMock
+
+    @BindValue
+    val boundNotificationManager: NotificationManager = reminderContext.notificationManagerFake.mock
+
+    @BindValue
+    val boundMedicineRepository: com.futsch1.medtimer.core.domain.repository.MedicineRepository =
+        reminderContext.repositoryFakes.medicineRepositoryMock
+
+    @BindValue
+    val boundReminderRepository: com.futsch1.medtimer.core.domain.repository.ReminderRepository =
+        reminderContext.repositoryFakes.reminderRepositoryMock
+
+    @BindValue
+    val boundReminderEventRepository: com.futsch1.medtimer.core.domain.repository.ReminderEventRepository =
+        reminderContext.repositoryFakes.reminderEventRepositoryMock
+
+    @BindValue
+    val boundPreferencesDataSource: com.futsch1.medtimer.core.datastore.PreferencesDataSource =
+        reminderContext.preferencesDataSourceMock
+
+    @BindValue
+    val boundPersistentDataDataSource: com.futsch1.medtimer.core.datastore.PersistentDataDataSource =
+        reminderContext.persistentDataDataSourceMock
+
+    @BindValue
+    val boundTimeAccess: com.futsch1.medtimer.core.common.time.TimeAccess = object : com.futsch1.medtimer.core.common.time.TimeAccess {
+        override fun systemZone(): java.time.ZoneId = java.time.ZoneId.of("UTC")
+        override fun localDate(): java.time.LocalDate = reminderContext.localDate
+        override fun now(): java.time.Instant = reminderContext.instant
+    }
+
+    @BindValue
+    val boundMedicineRoomDatabase: com.futsch1.medtimer.database.MedicineRoomDatabase = org.mockito.Mockito.mock()
+
+    @BindValue
+    val boundMedicineDao: MedicineDao = org.mockito.Mockito.mock()
+
+    @BindValue
+    val boundReminderDao: ReminderDao = org.mockito.Mockito.mock()
+
+    @BindValue
+    val boundReminderEventDao: ReminderEventDao = org.mockito.Mockito.mock()
+
+    @BindValue
+    val boundTagDao: TagDao = org.mockito.Mockito.mock()
+
+    @BindValue
+    val boundTagRepository: com.futsch1.medtimer.core.domain.repository.TagRepository = org.mockito.Mockito.mock()
+
+    @BindValue
+    val boundDatabaseManager: com.futsch1.medtimer.database.DatabaseManager = org.mockito.Mockito.mock()
+
+    @BindValue
+    val boundBackupRepository: com.futsch1.medtimer.core.domain.repository.BackupRepository = org.mockito.Mockito.mock()
+
+    @BindValue
+    @com.futsch1.medtimer.core.datastore.di.DefaultPreferences
+    val boundDefaultSharedPreferences: android.content.SharedPreferences = org.mockito.Mockito.mock()
+
+    @BindValue
+    @com.futsch1.medtimer.core.datastore.di.MedTimerPreferences
+    val boundMedTimerSharedPreferences: android.content.SharedPreferences = org.mockito.Mockito.mock()
+
+    @Inject
+    lateinit var scheduleNextReminderNotificationProcessor: ScheduleNextReminderNotificationProcessor
+
+    /** Reminder time in minutes since midnight: 600 = 10:00 on the fixed test day (epoch day 0, UTC). */
+    private val reminderTimeInMinutes = 600
+
+    /**
+     * The reported bug: a reminder due at 10:00 with `automaticallyTaken` that was missed
+     * because the device was off must be **added as TAKEN** when the app reschedules after boot.
+     */
+    @Test
+    fun missedAutomaticallyTakenReminderIsAddedAsTaken() {
+        // Given: a medicine with an automatically-taken reminder due at 10:00
+        reminderContext.repositoryFakes.medicines.add(MedicineEntity("Vitamin X 500 mg").also { it.medicineId = 1 })
+        reminderContext.repositoryFakes.reminders.add(
+            TestHelper.buildReminder(1, 1, "1", reminderTimeInMinutes, 1)
+                .copy(automaticallyTaken = true)
+                .toEntity()
+        )
+
+        // And: the phone was off at 10:00 — no reminder event was created, and it is now 11:00
+        reminderContext.instant = Instant.ofEpochSecond(11 * 60 * 60)
+
+        // When: the app reschedules after boot
+        runBlocking {
+            scheduleNextReminderNotificationProcessor.scheduleNextReminder()
+        }
+
+        // Then: the missed medication was added as taken (this is the expected behaviour from the issue)
+        val events = reminderContext.repositoryFakes.reminderEvents.map { it.toModel() }
+        assertEquals(1, events.size, "Expected exactly one reminder event for the missed reminder")
+        assertEquals(
+            10 * 60 * 60L,
+            events[0].remindedTimestamp.epochSecond,
+            "The event must carry the original (missed) reminder time of 10:00"
+        )
+        assertEquals(
+            ReminderEvent.ReminderStatus.TAKEN,
+            events[0].status,
+            "The automatically-taken reminder must be marked as taken"
+        )
+    }
+
+    /**
+     * Control case: a *normal* (not automatically-taken) missed reminder must still be created
+     * (as RAISED — the notification is then shown to the user). This documents the difference
+     * between the two reminder kinds and guards the scheduling catch-up itself.
+     */
+    @Test
+    fun missedNonAutomaticallyTakenReminderIsRaised() {
+        // Given: a medicine with a normal reminder due at 10:00
+        reminderContext.repositoryFakes.medicines.add(MedicineEntity("Vitamin X 500 mg").also { it.medicineId = 1 })
+        reminderContext.repositoryFakes.reminders.add(
+            TestHelper.buildReminder(1, 1, "1", reminderTimeInMinutes, 1)
+                .copy(automaticallyTaken = false)
+                .toEntity()
+        )
+
+        // And: the phone was off at 10:00 — no reminder event was created, and it is now 11:00
+        reminderContext.instant = Instant.ofEpochSecond(11 * 60 * 60)
+
+        // When: the app reschedules after boot
+        runBlocking {
+            scheduleNextReminderNotificationProcessor.scheduleNextReminder()
+        }
+
+        // Then: the missed reminder event exists and is raised (awaiting user action)
+        val events = reminderContext.repositoryFakes.reminderEvents.map { it.toModel() }
+        assertEquals(1, events.size, "Expected exactly one reminder event for the missed reminder")
+        assertEquals(ReminderEvent.ReminderStatus.RAISED, events[0].status)
+    }
+
+    /**
+     * Contrast case: with the device on *before* the reminder time, scheduling must not create
+     * any event yet — it only arms the alarm. This guards against the test scenario being
+     * trivially green because events are created unconditionally.
+     */
+    @Test
+    fun deviceOnAtReminderTime() {
+        // Given: a medicine with an automatically-taken reminder due at 10:00
+        reminderContext.repositoryFakes.medicines.add(MedicineEntity("Vitamin X 500 mg").also { it.medicineId = 1 })
+        reminderContext.repositoryFakes.reminders.add(
+            TestHelper.buildReminder(1, 1, "1", reminderTimeInMinutes, 1)
+                .copy(automaticallyTaken = true)
+                .toEntity()
+        )
+
+        // And: the device is on and it is 09:00 — before the reminder time
+        reminderContext.instant = Instant.ofEpochSecond(9 * 60 * 60)
+
+        // When: the app schedules
+        runBlocking {
+            scheduleNextReminderNotificationProcessor.scheduleNextReminder()
+        }
+
+        // Then: no event exists yet and an alarm was armed for 10:00
+        assertEquals(
+            0,
+            reminderContext.repositoryFakes.reminderEvents.size,
+            "No event may be created while the reminder is still in the future"
+        )
+        verify(reminderContext.alarmManagerMock, times(1)).setAndAllowWhileIdle(
+            org.mockito.ArgumentMatchers.anyInt(),
+            org.mockito.ArgumentMatchers.eq(reminderTimeInMinutes * 60 * 1000L),
+            org.mockito.ArgumentMatchers.any()
+        )
+        verify(reminderContext.alarmManagerMock, never()).cancel(org.mockito.ArgumentMatchers.any<PendingIntent>())
+    }
+}

--- a/app/src/test/java/com/futsch1/medtimer/processortests/TestReminderContext.kt
+++ b/app/src/test/java/com/futsch1/medtimer/processortests/TestReminderContext.kt
@@ -68,7 +68,7 @@ class RepositoryFakes {
             val reminderEvent = (it.arguments[0] as ReminderEvent).toEntity()
             reminderEvent.reminderEventId = reminderEvents.size + 1
             reminderEvents.add(reminderEvent)
-            reminderEvents.size.toLong()
+            reminderEvent.toModel()
         }
         `when`(runBlocking { reminderEventRepositoryMock.update(any()) }).thenAnswer {
             val domainEvent = it.arguments[0] as ReminderEvent


### PR DESCRIPTION
## Summary

Regression tests for #1418 ("Battery dead = missing medications"). When the phone is
off at the time an automatically taken dose is due, that dose should still be recorded
as taken. The behavior already exists on `main` (fix `e657feb2`, December 2025, which
predates the issue). This PR adds tests so it cannot break unnoticed.

No production code changes.

## Changes

- **`MissedAutomaticallyTakenReminderTest`** (JVM / Robolectric, new): three scenarios.
  A missed automatically taken reminder is caught up and recorded as `TAKEN`. A missed
  reminder without that flag is raised instead. A reminder that fires right on time
  behaves correctly. This is the first JVM test for the catch-up path; nothing on `main`
  covered it before.
- **`MissedAutomaticallyTakenInstrumentedTest`** (instrumented, new): the scenario from
  the issue, end to end on a device. An automatically taken reminder with a past time is
  caught up and shown as taken in the overview, and no "taken" action stays in the
  notification shade. This complements `NotificationTest.automaticallyTakenTest`, which
  fires at a future time.
- **`TestReminderContext` fake fix**: the `create()` stub returned a `Long` where the
  repository interface declares `ReminderEvent`. Any test using that path crashed. No
  existing test hit it; the new one did.

## Testing

- JVM: `MissedAutomaticallyTakenReminderTest`, 3/3 green. Also verified from a clean
  checkout of `main` with the fake fix applied.
- Instrumented (Android 16 emulator, API 36): the new test passes 1/1, and the existing
  `NotificationTest.automaticallyTakenTest` passes 1/1 on the same code.
- Test data is synthetic ("Test med").

*AI was used to create this pull request*
